### PR TITLE
feat: read data parts API

### DIFF
--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -15,7 +15,6 @@
 //! The value part of key-value separated merge-tree structure.
 
 use std::cmp::{Ordering, Reverse};
-use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -46,10 +45,12 @@ pub const PK_INDEX_COLUMN_NAME: &str = "pk_index";
 
 /// Data part batches returns by `DataParts::read`.
 pub struct DataBatch {
+    /// Primary key index of this batch.
+    pk_index: PkIndex,
     /// Record batch of data.
     rb: RecordBatch,
-    /// The ranges of all primary key offsets inside batch.
-    pk_index_ranges: HashMap<PkIndex, Range<usize>>,
+    /// Range of current primary key inside record batch
+    range: Range<usize>,
 }
 
 /// Data parts including an active writing part and several frozen parts.
@@ -65,13 +66,11 @@ impl DataParts {
     }
 
     /// Reads data from all parts including active and frozen parts.
-    pub fn read(&mut self, pk_weights: &[u16]) -> Result<Vec<DataBatch>> {
-        let mut batches = Vec::with_capacity(1 + self.frozen.len());
-        batches.push(self.active.read(pk_weights)?);
-        for p in &self.frozen {
-            batches.push(p.read(pk_weights)?);
-        }
-        Ok(batches)
+    /// The returned iterator yields a record batch of one primary key at a time.
+    /// The order of yielding primary keys is determined by provided weights.
+    pub fn iter(&mut self, _pk_weights: &[u16]) -> Result<impl Iterator<Item = DataBatch>> {
+        todo!();
+        Ok(std::iter::empty())
     }
 }
 

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -59,6 +59,19 @@ pub struct DataParts {
     frozen: Vec<DataPart>, // todo(hl): merge all frozen parts into one parquet-encoded bytes.
 }
 
+/// Iterator for iterating data in `DataParts`
+pub struct Iter {
+    // todo
+}
+
+impl Iterator for Iter {
+    type Item = Result<DataBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
 impl DataParts {
     /// Writes one row into active part.
     pub fn write_row(&mut self, pk_id: PkId, kv: KeyValue) {
@@ -68,9 +81,9 @@ impl DataParts {
     /// Reads data from all parts including active and frozen parts.
     /// The returned iterator yields a record batch of one primary key at a time.
     /// The order of yielding primary keys is determined by provided weights.
-    pub fn iter(&mut self, _pk_weights: &[u16]) -> Result<impl Iterator<Item = DataBatch>> {
-        todo!();
-        Ok(std::iter::empty())
+    pub fn iter(&mut self, _pk_weights: &[u16]) -> Result<Iter> {
+        let iter = todo!();
+        Ok(iter)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?


Read data batches from `DataParts`.

`DataParts` contains one active buffer and several frozen parts. Each of these parts returns a `DataBatch` while read. `DataBatch` contains a `arrow::record_batch::RecordBatch` and a hashmap indicates the offset ranges of every primary kety index.
## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
