### PR TITLE
feat: data parts iter

### DIFF
--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -1062,7 +1062,7 @@ mod tests {
         };
         let mut iter = parts.iter(pk_weights).unwrap();
         let mut res = Vec::with_capacity(expected_values.len());
-        while let Some(b) = iter.next() {
+        for b in iter {
             let batch = b.unwrap().as_record_batch();
             let values = batch
                 .column_by_name("v1")


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR implements the `iter` method for `DataParts`. The iterator is simply a merge reader that compares the pk from both active and frozen parts of `DataParts` and merges those `DataBatches` with same pk index.

## Note

Currently the iterator only compares pk index and does not consider timestamp/sequence.



## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
