### PR TITLE
feat: finish read/write for single shard

### DIFF
--- a/src/mito2/src/memtable.rs
+++ b/src/mito2/src/memtable.rs
@@ -60,7 +60,7 @@ impl MemtableStats {
     }
 }
 
-pub type BoxedBatchIterator = Box<dyn Iterator<Item = Result<Batch>> + Send + Sync>;
+pub type BoxedBatchIterator = Box<dyn Iterator<Item = Result<Batch>> + Send>;
 
 /// In memory write buffer.
 pub trait Memtable: Send + Sync + fmt::Debug {

--- a/src/mito2/src/memtable/merge_tree.rs
+++ b/src/mito2/src/memtable/merge_tree.rs
@@ -56,6 +56,8 @@ pub(crate) struct PkId {
 pub struct MergeTreeConfig {
     /// Max keys in an index shard.
     index_max_keys_per_shard: usize,
+    /// Freeze threshold of data parts.
+    freeze_threshold: usize,
 }
 
 impl Default for MergeTreeConfig {
@@ -63,6 +65,7 @@ impl Default for MergeTreeConfig {
         Self {
             // TODO(yingwen): Use 4096 or find a proper value.
             index_max_keys_per_shard: 8192,
+            freeze_threshold: 4096,
         }
     }
 }

--- a/src/mito2/src/memtable/merge_tree/data.rs
+++ b/src/mito2/src/memtable/merge_tree/data.rs
@@ -1062,7 +1062,7 @@ mod tests {
         };
         let mut iter = parts.iter(pk_weights).unwrap();
         let mut res = Vec::with_capacity(expected_values.len());
-        while let Some(b) = iter.next() {
+        for b in iter {
             let batch = b.unwrap().as_record_batch();
             let values = batch
                 .column_by_name("v1")

--- a/src/mito2/src/memtable/merge_tree/tree.rs
+++ b/src/mito2/src/memtable/merge_tree/tree.rs
@@ -19,7 +19,6 @@ use std::sync::{Arc, RwLock};
 
 use api::v1::OpType;
 use common_time::Timestamp;
-use datatypes::arrow::array::ArrayRef;
 use datatypes::arrow::record_batch::RecordBatch;
 use snafu::ensure;
 use store_api::metadata::RegionMetadataRef;
@@ -28,14 +27,14 @@ use table::predicate::Predicate;
 
 use crate::error::{PrimaryKeyLengthMismatchSnafu, Result};
 use crate::memtable::key_values::KeyValue;
-use crate::memtable::merge_tree::data::{self, DataBatch, DataBuffer, DataParts};
+use crate::memtable::merge_tree::data::{self, DataBatch, DataParts};
 use crate::memtable::merge_tree::index::{
-    IndexConfig, IndexReader, KeyIndex, KeyIndexRef, ShardReader,
+    compute_pk_weights, IndexConfig, IndexReader, KeyIndex, KeyIndexRef, ShardReader,
 };
 use crate::memtable::merge_tree::mutable::WriteMetrics;
 use crate::memtable::merge_tree::{MergeTreeConfig, PkId, PkIndex};
 use crate::memtable::{BoxedBatchIterator, KeyValues};
-use crate::read::{Batch, BatchBuilder, BatchColumn};
+use crate::read::{Batch, BatchBuilder};
 use crate::row_converter::{McmpRowCodec, RowCodec, SortField};
 
 /// Initial capacity for the data buffer.
@@ -69,10 +68,11 @@ impl MergeTree {
                 max_keys_per_shard: config.index_max_keys_per_shard,
             }))
         });
+        let data = DataParts::with_capacity(metadata.clone(), DATA_INIT_CAP);
         let parts = TreeParts {
             immutable: false,
             index,
-            data: DataParts::new(metadata.clone(), DATA_INIT_CAP),
+            data,
         };
 
         MergeTree {
@@ -113,7 +113,7 @@ impl MergeTree {
                     shard_id: 0,
                     pk_index: 0,
                 };
-                self.write_with_id(pk_id, kv);
+                self.write_with_id(pk_id, kv)?;
                 continue;
             }
 
@@ -157,7 +157,7 @@ impl MergeTree {
         // Compute pk weights.
         let mut pk_weights = Vec::new();
         if let Some(reader) = &index_reader {
-            reader.compute_pk_weights(&mut pk_weights);
+            compute_pk_weights(reader.sorted_pk_index(), &mut pk_weights);
         } else {
             // Push weight for the only key.
             // TODO(yingwen): Allow passing empty weights if there is no primary key.
@@ -166,7 +166,7 @@ impl MergeTree {
 
         let data_iter = {
             let mut parts = self.parts.write().unwrap();
-            parts.data.iter(&pk_weights)?
+            parts.data.iter(pk_weights)?
         };
 
         let iter = ShardIter {
@@ -249,15 +249,26 @@ impl MergeTree {
         // Write the pk to the index.
         let pk_id = self.write_primary_key(primary_key, metrics)?;
         // Writes data.
-        self.write_with_id(pk_id, kv);
-
-        Ok(())
+        self.write_with_id(pk_id, kv)
     }
 
-    fn write_with_id(&self, pk_id: PkId, kv: KeyValue) {
+    fn write_with_id(&self, pk_id: PkId, kv: KeyValue) -> Result<()> {
         let mut parts = self.parts.write().unwrap();
         assert!(!parts.immutable);
-        parts.data.write_row(pk_id, kv)
+        if parts.data.write_row(pk_id, kv) {
+            // should trigger freeze
+            let weights = if let Some(index) = parts.index.as_ref() {
+                let pk_indices = index.sorted_pk_indices();
+                let mut weights = Vec::with_capacity(pk_indices.len());
+                compute_pk_weights(&pk_indices, &mut weights);
+                weights
+            } else {
+                vec![0]
+            };
+            parts.data.freeze(&weights)
+        } else {
+            Ok(())
+        }
     }
 
     fn write_primary_key(&self, key: &[u8], metrics: &mut WriteMetrics) -> Result<PkId> {
@@ -391,7 +402,7 @@ impl DataReader {
             .zip(record_batch.schema().fields().iter())
             .skip(4)
         {
-            // Safety: metadata should contains all fields.
+            // Safety: metadata should contain all fields.
             let column_id = metadata.column_by_name(field.name()).unwrap().column_id;
             if !projection.contains(&column_id) {
                 continue;


### PR DESCRIPTION
I hereby agree to the terms of the [GreptimeDB CLA](https://gist.github.com/xtang/6378857777706e568c1949c7578592cc)

## What's changed and what's your intention?

This PR implements the iter method for `DataParts`. The iterator is simply a merge reader that compares the pk from both active and frozen parts of `DataParts` and merges those `DataBatch`es with same pk index.

Also `freeze` will be triggered on write path of the num of rows inside active data buffer exceeds `freeze_threshold` in `MergeTreeConfig`.


## Checklist

- [ ]  I have written the necessary rustdoc comments.
- [ ]  I have added the necessary unit tests and integration tests.
- [x]  This PR does not require documentation updates.

## Refer to a related PR or issue link (optional)
