### PR TITLE
Add aggregate index POC and datanode `AggrIndex` CLI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,7 @@ dependencies = [
  "flow",
  "frontend",
  "futures",
+ "hex",
  "human-panic",
  "humantime",
  "lazy_static",

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -64,6 +64,7 @@ etcd-client.workspace = true
 flow.workspace = true
 frontend = { workspace = true, default-features = false }
 futures.workspace = true
+hex.workspace = true
 human-panic = "2.0"
 humantime.workspace = true
 lazy_static.workspace = true

--- a/src/cmd/src/bin/greptime.rs
+++ b/src/cmd/src/bin/greptime.rs
@@ -113,6 +113,7 @@ async fn start(cli: Command) -> Result<()> {
             }
             datanode::SubCommand::Objbench(ref bench) => bench.run().await,
             datanode::SubCommand::Scanbench(ref bench) => bench.run().await,
+            datanode::SubCommand::AggrIndex(ref cmd) => cmd.run().await,
         },
         SubCommand::Flownode(cmd) => {
             cmd.build(cmd.load_options(&cli.global_options)?)

--- a/src/cmd/src/datanode.rs
+++ b/src/cmd/src/datanode.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[allow(clippy::print_stdout)]
+mod aggr_index;
 pub mod builder;
 #[allow(clippy::print_stdout)]
 mod objbench;
@@ -35,6 +37,7 @@ use snafu::{ResultExt, ensure};
 use tracing_appender::non_blocking::WorkerGuard;
 
 use crate::App;
+use crate::datanode::aggr_index::AggrIndexCommand;
 use crate::datanode::builder::InstanceBuilder;
 use crate::datanode::objbench::ObjbenchCommand;
 use crate::datanode::scanbench::ScanbenchCommand;
@@ -108,7 +111,7 @@ impl Command {
     pub fn load_options(&self, global_options: &GlobalOptions) -> Result<DatanodeOptions> {
         match &self.subcmd {
             SubCommand::Start(cmd) => cmd.load_options(global_options),
-            SubCommand::Objbench(_) | SubCommand::Scanbench(_) => {
+            SubCommand::Objbench(_) | SubCommand::Scanbench(_) | SubCommand::AggrIndex(_) => {
                 // For bench commands, we don't need to load DatanodeOptions
                 // They are standalone utility commands
                 let mut opts = datanode::config::DatanodeOptions::default();
@@ -130,6 +133,8 @@ pub enum SubCommand {
     Objbench(ObjbenchCommand),
     /// Scan benchmark tool - benchmarks scanning a region directly from storage
     Scanbench(ScanbenchCommand),
+    /// Aggregate index POC tool
+    AggrIndex(AggrIndexCommand),
 }
 
 impl SubCommand {
@@ -144,6 +149,10 @@ impl SubCommand {
                 std::process::exit(0);
             }
             SubCommand::Scanbench(cmd) => {
+                cmd.run().await?;
+                std::process::exit(0);
+            }
+            SubCommand::AggrIndex(cmd) => {
                 cmd.run().await?;
                 std::process::exit(0);
             }

--- a/src/cmd/src/datanode/aggr_index.rs
+++ b/src/cmd/src/datanode/aggr_index.rs
@@ -1,0 +1,307 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+use std::path::{Path, PathBuf};
+
+use clap::{Parser, Subcommand, ValueEnum};
+use colored::Colorize;
+use datatypes::arrow::array::{BinaryArray, Int64Array, StringArray, UInt32Array, UInt64Array};
+use mito2::aggr_index::index_io::IndexReader;
+use mito2::aggr_index::input::{merge_sources, open_sst_stream, validate_same_schema};
+use mito2::aggr_index::{IndexKind, build_indexes, merge_index_files};
+use mito2::sst::file::FileMeta;
+use snafu::OptionExt;
+use store_api::storage::FileId;
+
+use crate::datanode::objbench::{build_object_store, parse_config};
+use crate::datanode::scanbench::{parse_path_type, parse_region_id};
+use crate::error;
+
+#[derive(Debug, Parser)]
+pub struct AggrIndexCommand {
+    #[clap(subcommand)]
+    subcmd: AggrIndexSubCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum AggrIndexSubCommand {
+    Build(BuildCommand),
+    Merge(MergeCommand),
+    Read(ReadCommand),
+}
+
+#[derive(Debug, Parser)]
+struct BuildCommand {
+    #[clap(long, value_name = "FILE")]
+    config: PathBuf,
+    #[clap(long)]
+    table_dir: String,
+    #[clap(long, default_value = "bare")]
+    path_type: String,
+    #[clap(long)]
+    region_id: String,
+    #[clap(long, required = true)]
+    input: Vec<String>,
+    #[clap(long)]
+    output_dir: PathBuf,
+    #[clap(long, alias = "buffer-rows", default_value_t = 8 * 1024 * 1024)]
+    buffer_bytes: usize,
+}
+
+#[derive(Debug, Parser)]
+struct MergeCommand {
+    #[clap(long, value_enum)]
+    kind: CliKind,
+    #[clap(long, required = true)]
+    input: Vec<PathBuf>,
+    #[clap(long)]
+    output: PathBuf,
+}
+
+#[derive(Debug, Parser)]
+struct ReadCommand {
+    #[clap(long, value_enum)]
+    kind: CliKind,
+    #[clap(long)]
+    input: PathBuf,
+    #[clap(long)]
+    table_id: Option<u32>,
+    #[clap(long)]
+    column_id: Option<u32>,
+    #[clap(long)]
+    tag_value: Option<String>,
+    #[clap(long)]
+    primary_key_hex: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliKind {
+    Pk,
+    TableTag,
+    Tag,
+}
+impl From<CliKind> for IndexKind {
+    fn from(v: CliKind) -> Self {
+        match v {
+            CliKind::Pk => IndexKind::Pk,
+            CliKind::TableTag => IndexKind::TableTag,
+            CliKind::Tag => IndexKind::Tag,
+        }
+    }
+}
+
+impl AggrIndexCommand {
+    pub async fn run(&self) -> error::Result<()> {
+        match &self.subcmd {
+            AggrIndexSubCommand::Build(cmd) => cmd.run().await,
+            AggrIndexSubCommand::Merge(cmd) => cmd.run(),
+            AggrIndexSubCommand::Read(cmd) => cmd.run(),
+        }
+    }
+}
+
+impl BuildCommand {
+    async fn run(&self) -> error::Result<()> {
+        let (store_cfg, _, _) = parse_config(&self.config)?;
+        let object_store = build_object_store(&store_cfg).await?;
+        let region_id = parse_region_id(&self.region_id)?;
+        let path_type = parse_path_type(&self.path_type)?;
+        let mut streams = Vec::new();
+        let mut metadata = None;
+        let mut schema = None;
+        for input in &self.input {
+            let path = sst_path(&self.table_dir, path_type, input);
+            let stat = object_store.stat(&path).await.map_err(|e| {
+                error::IllegalConfigSnafu {
+                    msg: format!("stat {path} failed: {e}"),
+                }
+                .build()
+            })?;
+            let file_id = parse_file_id(input)?;
+            let file_meta = FileMeta {
+                region_id,
+                file_id,
+                file_size: stat.content_length(),
+                ..Default::default()
+            };
+            let sst = open_sst_stream(
+                self.table_dir.clone(),
+                path_type,
+                object_store.clone(),
+                file_meta,
+            )
+            .await
+            .map_err(to_cmd_err)?;
+            if let Some(expected) = &schema {
+                validate_same_schema(expected, &sst.schema).map_err(to_cmd_err)?;
+            } else {
+                schema = Some(sst.schema.clone());
+            }
+            if metadata.is_none() {
+                metadata = Some(sst.metadata.clone());
+            }
+            streams.push(sst.stream);
+        }
+        let schema = schema.context(error::IllegalConfigSnafu {
+            msg: "no input SSTs",
+        })?;
+        let metadata = metadata.context(error::IllegalConfigSnafu {
+            msg: "no input SST metadata",
+        })?;
+        let merged = merge_sources(schema, streams).await.map_err(to_cmd_err)?;
+        let output = build_indexes(metadata, merged, &self.output_dir, self.buffer_bytes)
+            .await
+            .map_err(to_cmd_err)?;
+        print_file("pk", &output.pk_path, output.pk_rows)?;
+        print_file("table-tag", &output.table_tag_path, output.table_tag_rows)?;
+        print_file("tag", &output.tag_path, output.tag_rows)?;
+        Ok(())
+    }
+}
+
+impl MergeCommand {
+    fn run(&self) -> error::Result<()> {
+        let rows =
+            merge_index_files(self.kind.into(), &self.input, &self.output).map_err(to_cmd_err)?;
+        print_file("merged", &self.output, rows)
+    }
+}
+
+impl ReadCommand {
+    fn run(&self) -> error::Result<()> {
+        let kind = self.kind.into();
+        let tag_value = self.tag_value.as_deref();
+        let primary_key = self
+            .primary_key_hex
+            .as_deref()
+            .map(hex::decode)
+            .transpose()
+            .map_err(|e| {
+                error::IllegalConfigSnafu {
+                    msg: format!("invalid primary-key-hex: {e}"),
+                }
+                .build()
+            })?;
+        let mut reader = IndexReader::try_new(&self.input, kind).map_err(to_cmd_err)?;
+        for batch in &mut reader {
+            let batch = batch.map_err(to_cmd_err)?;
+            match kind {
+                IndexKind::Pk => print_pk(&batch, primary_key.as_deref())?,
+                IndexKind::TableTag => {
+                    print_table_tag(&batch, self.table_id, self.column_id, tag_value)?
+                }
+                IndexKind::Tag => print_tag(&batch, self.column_id, tag_value)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+fn print_pk(
+    batch: &datatypes::arrow::record_batch::RecordBatch,
+    filter: Option<&[u8]>,
+) -> error::Result<()> {
+    let pk = col::<BinaryArray>(batch, 0)?;
+    let min = col::<Int64Array>(batch, 1)?;
+    let max = col::<Int64Array>(batch, 2)?;
+    let cnt = col::<UInt64Array>(batch, 3)?;
+    for i in 0..batch.num_rows() {
+        if filter.is_none_or(|f| f == pk.value(i)) {
+            println!(
+                "pk={} min_ts={} max_ts={} row_count={}",
+                hex::encode(pk.value(i)),
+                min.value(i),
+                max.value(i),
+                cnt.value(i)
+            );
+        }
+    }
+    Ok(())
+}
+fn print_table_tag(
+    batch: &datatypes::arrow::record_batch::RecordBatch,
+    table_filter: Option<u32>,
+    col_filter: Option<u32>,
+    val_filter: Option<&str>,
+) -> error::Result<()> {
+    let t = col::<UInt32Array>(batch, 0)?;
+    let c = col::<UInt32Array>(batch, 1)?;
+    let v = col::<StringArray>(batch, 2)?;
+    for i in 0..batch.num_rows() {
+        if table_filter.is_none_or(|x| x == t.value(i))
+            && col_filter.is_none_or(|x| x == c.value(i))
+            && val_filter.is_none_or(|x| x == v.value(i))
+        {
+            println!(
+                "table_id={} column_id={} tag_value={}",
+                t.value(i),
+                c.value(i),
+                v.value(i)
+            );
+        }
+    }
+    Ok(())
+}
+fn print_tag(
+    batch: &datatypes::arrow::record_batch::RecordBatch,
+    col_filter: Option<u32>,
+    val_filter: Option<&str>,
+) -> error::Result<()> {
+    let c = col::<UInt32Array>(batch, 0)?;
+    let v = col::<StringArray>(batch, 1)?;
+    for i in 0..batch.num_rows() {
+        if col_filter.is_none_or(|x| x == c.value(i)) && val_filter.is_none_or(|x| x == v.value(i))
+        {
+            println!("column_id={} tag_value={}", c.value(i), v.value(i));
+        }
+    }
+    Ok(())
+}
+fn col<T: 'static>(
+    batch: &datatypes::arrow::record_batch::RecordBatch,
+    idx: usize,
+) -> error::Result<&T> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<T>()
+        .context(error::IllegalConfigSnafu {
+            msg: format!("invalid index column {idx}"),
+        })
+}
+
+fn sst_path(table_dir: &str, path_type: store_api::region_request::PathType, file: &str) -> String {
+    match path_type {
+        store_api::region_request::PathType::Bare => format!("{table_dir}/{file}"),
+        store_api::region_request::PathType::Data => format!("{table_dir}/data/{file}"),
+        store_api::region_request::PathType::Metadata => format!("{table_dir}/metadata/{file}"),
+    }
+}
+fn parse_file_id(input: &str) -> error::Result<FileId> {
+    let stem = Path::new(input)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(input.trim_end_matches(".parquet"));
+    FileId::parse_str(stem).map_err(|e| {
+        error::IllegalConfigSnafu {
+            msg: format!("invalid SST filename {input}: {e}"),
+        }
+        .build()
+    })
+}
+fn to_cmd_err(e: mito2::error::Error) -> error::Error {
+    error::IllegalConfigSnafu { msg: e.to_string() }.build()
+}
+fn print_file(label: &str, path: &Path, rows: usize) -> error::Result<()> {
+    let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    println!(
+        "{} {} rows={} size={} path={}",
+        "✓".green(),
+        label,
+        rows,
+        size,
+        path.display()
+    );
+    Ok(())
+}

--- a/src/cmd/src/datanode/scanbench.rs
+++ b/src/cmd/src/datanode/scanbench.rs
@@ -181,7 +181,7 @@ fn format_bytes(bytes: u64) -> String {
     }
 }
 
-fn parse_region_id(s: &str) -> error::Result<RegionId> {
+pub(super) fn parse_region_id(s: &str) -> error::Result<RegionId> {
     if s.contains(':') {
         let parts: Vec<&str> = s.splitn(2, ':').collect();
         let table_id: u32 = parts[0].parse().map_err(|e| {
@@ -208,7 +208,7 @@ fn parse_region_id(s: &str) -> error::Result<RegionId> {
     }
 }
 
-fn parse_path_type(s: &str) -> error::Result<PathType> {
+pub(super) fn parse_path_type(s: &str) -> error::Result<PathType> {
     match s.to_lowercase().as_str() {
         "bare" => Ok(PathType::Bare),
         "data" => Ok(PathType::Data),

--- a/src/mito2/src/aggr_index/builder.rs
+++ b/src/mito2/src/aggr_index/builder.rs
@@ -1,0 +1,431 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+use std::collections::BTreeSet;
+use std::mem;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use datatypes::arrow::array::{
+    Array, BinaryArray, DictionaryArray, Int64Array, StringArray, UInt32Array, UInt64Array,
+};
+use datatypes::arrow::datatypes::{DataType, UInt32Type};
+use datatypes::arrow::record_batch::RecordBatch;
+use futures::StreamExt;
+use mito_codec::row_converter::{CompositeValues, build_primary_key_codec};
+use snafu::{OptionExt, ResultExt, ensure};
+use store_api::codec::PrimaryKeyEncoding;
+use store_api::metadata::RegionMetadataRef;
+use store_api::storage::consts::ReservedColumnId;
+
+use crate::aggr_index::index_io::IndexWriter;
+use crate::aggr_index::merge::merge_index_files;
+use crate::aggr_index::schema::{IndexKind, is_reserved_tag_column};
+use crate::error::{InvalidMetaSnafu, InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result};
+use crate::read::BoxedRecordBatchStream;
+use crate::sst::parquet::flat_format::{primary_key_column_index, time_index_column_index};
+
+const PK_WRITE_BUFFER_ROWS: usize = 1024;
+
+#[derive(Debug, Clone)]
+pub struct BuildOutput {
+    pub pk_path: PathBuf,
+    pub table_tag_path: PathBuf,
+    pub tag_path: PathBuf,
+    pub pk_rows: usize,
+    pub table_tag_rows: usize,
+    pub tag_rows: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct TableTagKey {
+    table_id: u32,
+    column_id: u32,
+    value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct TagKey {
+    column_id: u32,
+    value: String,
+}
+
+#[derive(Debug)]
+struct PkIndexRow {
+    pk: Vec<u8>,
+    min_ts: i64,
+    max_ts: i64,
+    row_count: u64,
+}
+
+pub async fn build_indexes(
+    metadata: RegionMetadataRef,
+    mut stream: BoxedRecordBatchStream,
+    output_dir: impl AsRef<Path>,
+    buffer_bytes: usize,
+) -> Result<BuildOutput> {
+    ensure!(
+        metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse,
+        InvalidMetaSnafu {
+            reason: "aggregate index only supports sparse primary-key encoding"
+        }
+    );
+
+    std::fs::create_dir_all(output_dir.as_ref()).map_err(|e| {
+        external_error(
+            e,
+            format!("create output dir {}", output_dir.as_ref().display()),
+        )
+    })?;
+
+    let pk_path = output_dir.as_ref().join(IndexKind::Pk.file_name());
+    let table_tag_path = output_dir.as_ref().join(IndexKind::TableTag.file_name());
+    let tag_path = output_dir.as_ref().join(IndexKind::Tag.file_name());
+    let mut pk_writer = IndexWriter::try_new(&pk_path, IndexKind::Pk.schema())?;
+    let codec = build_primary_key_codec(&metadata);
+
+    let mut current_pk: Option<Vec<u8>> = None;
+    let mut min_ts = i64::MAX;
+    let mut max_ts = i64::MIN;
+    let mut row_count = 0u64;
+    let mut pk_rows = 0usize;
+    let mut pk_buffer = Vec::with_capacity(PK_WRITE_BUFFER_ROWS);
+    let mut table_tags = BTreeSet::new();
+    let mut tags = BTreeSet::new();
+    let mut table_tag_runs = Vec::new();
+    let mut tag_runs = Vec::new();
+    let mut run_id = 0usize;
+    let mut tag_buffer_bytes = 0usize;
+    let tag_buffer_bytes_limit = buffer_bytes.max(1);
+
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        let pk_idx = primary_key_column_index(batch.num_columns());
+        let ts_idx = time_index_column_index(batch.num_columns());
+        let ts = timestamp_values(batch.column(ts_idx))?;
+        for (row, ts_value) in ts.iter().copied().enumerate().take(batch.num_rows()) {
+            let pk = primary_key_value(batch.column(pk_idx), row)?;
+            if current_pk.as_deref() != Some(pk.as_slice()) {
+                if let Some(prev) = current_pk.replace(pk.clone()) {
+                    buffer_pk_row(
+                        &mut pk_writer,
+                        &mut pk_buffer,
+                        prev,
+                        min_ts,
+                        max_ts,
+                        row_count,
+                    )?;
+                    pk_rows += 1;
+                }
+                min_ts = ts_value;
+                max_ts = ts_value;
+                row_count = 0;
+                tag_buffer_bytes += collect_tag_keys(
+                    &metadata,
+                    codec.decode(&pk).context(crate::error::DecodeSnafu)?,
+                    &mut table_tags,
+                    &mut tags,
+                )?;
+                if tag_buffer_bytes >= tag_buffer_bytes_limit {
+                    flush_runs(
+                        output_dir.as_ref(),
+                        &mut table_tags,
+                        &mut tags,
+                        &mut table_tag_runs,
+                        &mut tag_runs,
+                        &mut run_id,
+                    )?;
+                    tag_buffer_bytes = 0;
+                }
+            }
+            min_ts = min_ts.min(ts_value);
+            max_ts = max_ts.max(ts_value);
+            row_count += 1;
+        }
+    }
+    if let Some(prev) = current_pk.take() {
+        buffer_pk_row(
+            &mut pk_writer,
+            &mut pk_buffer,
+            prev,
+            min_ts,
+            max_ts,
+            row_count,
+        )?;
+        pk_rows += 1;
+    }
+    flush_pk_rows(&mut pk_writer, &mut pk_buffer)?;
+    pk_writer.close()?;
+    flush_runs(
+        output_dir.as_ref(),
+        &mut table_tags,
+        &mut tags,
+        &mut table_tag_runs,
+        &mut tag_runs,
+        &mut run_id,
+    )?;
+
+    let table_tag_rows = merge_or_empty(IndexKind::TableTag, &table_tag_runs, &table_tag_path)?;
+    let tag_rows = merge_or_empty(IndexKind::Tag, &tag_runs, &tag_path)?;
+    for path in table_tag_runs.into_iter().chain(tag_runs) {
+        let _ = std::fs::remove_file(path);
+    }
+
+    Ok(BuildOutput {
+        pk_path,
+        table_tag_path,
+        tag_path,
+        pk_rows,
+        table_tag_rows,
+        tag_rows,
+    })
+}
+
+fn collect_tag_keys(
+    metadata: &RegionMetadataRef,
+    values: CompositeValues,
+    table_tags: &mut BTreeSet<TableTagKey>,
+    tags: &mut BTreeSet<TagKey>,
+) -> Result<usize> {
+    let mut inserted_bytes = 0;
+    let CompositeValues::Sparse(sparse) = values else {
+        return InvalidMetaSnafu {
+            reason: "decoded primary key is not sparse",
+        }
+        .fail();
+    };
+    let table_id = match sparse.get(&ReservedColumnId::table_id()) {
+        Some(datatypes::value::Value::UInt32(v)) => *v,
+        other => {
+            return InvalidMetaSnafu {
+                reason: format!("missing/invalid sparse __table_id: {other:?}"),
+            }
+            .fail();
+        }
+    };
+    for col in metadata.primary_key_columns() {
+        if is_reserved_tag_column(col.column_id) {
+            continue;
+        }
+        if let Some(value) = sparse.get(&col.column_id) {
+            let datatypes::value::Value::String(value) = value else {
+                return InvalidMetaSnafu {
+                    reason: format!(
+                        "aggregate tag index expects string tag value for column {}, got {value:?}",
+                        col.column_id
+                    ),
+                }
+                .fail();
+            };
+            let value = value.as_utf8().to_string();
+            let table_tag_key = TableTagKey {
+                table_id,
+                column_id: col.column_id,
+                value: value.clone(),
+            };
+            if table_tags.insert(table_tag_key) {
+                inserted_bytes += mem::size_of::<TableTagKey>() + value.len();
+            }
+            let tag_value_len = value.len();
+            let tag_key = TagKey {
+                column_id: col.column_id,
+                value,
+            };
+            if tags.insert(tag_key) {
+                inserted_bytes += mem::size_of::<TagKey>() + tag_value_len;
+            }
+        }
+    }
+    Ok(inserted_bytes)
+}
+
+fn primary_key_value(array: &Arc<dyn Array>, row: usize) -> Result<Vec<u8>> {
+    match array.data_type() {
+        DataType::Binary => Ok(array
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .context(InvalidRecordBatchSnafu {
+                reason: "__primary_key is not BinaryArray",
+            })?
+            .value(row)
+            .to_vec()),
+        DataType::Dictionary(key, value)
+            if key.as_ref() == &DataType::UInt32 && value.as_ref() == &DataType::Binary =>
+        {
+            let dict = array
+                .as_any()
+                .downcast_ref::<DictionaryArray<UInt32Type>>()
+                .context(InvalidRecordBatchSnafu {
+                    reason: "__primary_key is not Dictionary(UInt32, Binary)",
+                })?;
+            let values = dict
+                .values()
+                .as_any()
+                .downcast_ref::<BinaryArray>()
+                .context(InvalidRecordBatchSnafu {
+                    reason: "__primary_key dictionary values are not binary",
+                })?;
+            Ok(values.value(dict.keys().value(row) as usize).to_vec())
+        }
+        other => InvalidRecordBatchSnafu {
+            reason: format!("unsupported __primary_key type {other:?}"),
+        }
+        .fail(),
+    }
+}
+
+fn timestamp_values(array: &Arc<dyn Array>) -> Result<Vec<i64>> {
+    if let Some(a) = array.as_any().downcast_ref::<Int64Array>() {
+        return Ok((0..a.len()).map(|i| a.value(i)).collect());
+    }
+    macro_rules! ts {
+        ($ty:ty) => {
+            if let Some(a) = array.as_any().downcast_ref::<$ty>() {
+                return Ok((0..a.len()).map(|i| a.value(i)).collect());
+            }
+        };
+    }
+    ts!(datatypes::arrow::array::TimestampSecondArray);
+    ts!(datatypes::arrow::array::TimestampMillisecondArray);
+    ts!(datatypes::arrow::array::TimestampMicrosecondArray);
+    ts!(datatypes::arrow::array::TimestampNanosecondArray);
+    InvalidRecordBatchSnafu {
+        reason: format!("unsupported time index type {:?}", array.data_type()),
+    }
+    .fail()
+}
+
+fn buffer_pk_row(
+    writer: &mut IndexWriter,
+    buffer: &mut Vec<PkIndexRow>,
+    pk: Vec<u8>,
+    min_ts: i64,
+    max_ts: i64,
+    row_count: u64,
+) -> Result<()> {
+    buffer.push(PkIndexRow {
+        pk,
+        min_ts,
+        max_ts,
+        row_count,
+    });
+    if buffer.len() >= PK_WRITE_BUFFER_ROWS {
+        flush_pk_rows(writer, buffer)?;
+    }
+    Ok(())
+}
+
+fn flush_pk_rows(writer: &mut IndexWriter, buffer: &mut Vec<PkIndexRow>) -> Result<()> {
+    if buffer.is_empty() {
+        return Ok(());
+    }
+
+    let batch = RecordBatch::try_new(
+        IndexKind::Pk.schema(),
+        vec![
+            Arc::new(BinaryArray::from_iter_values(
+                buffer.iter().map(|row| row.pk.as_slice()),
+            )) as _,
+            Arc::new(Int64Array::from(
+                buffer.iter().map(|row| row.min_ts).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(Int64Array::from(
+                buffer.iter().map(|row| row.max_ts).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(UInt64Array::from(
+                buffer.iter().map(|row| row.row_count).collect::<Vec<_>>(),
+            )) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    writer.write(&batch)?;
+    buffer.clear();
+    Ok(())
+}
+
+fn flush_runs(
+    output_dir: &Path,
+    table_tags: &mut BTreeSet<TableTagKey>,
+    tags: &mut BTreeSet<TagKey>,
+    table_tag_runs: &mut Vec<PathBuf>,
+    tag_runs: &mut Vec<PathBuf>,
+    run_id: &mut usize,
+) -> Result<()> {
+    if !table_tags.is_empty() {
+        let path = output_dir.join(format!(".table_tag_run_{run_id}.parquet"));
+        write_table_tag_file(&path, table_tags.iter())?;
+        table_tags.clear();
+        table_tag_runs.push(path);
+    }
+    if !tags.is_empty() {
+        let path = output_dir.join(format!(".tag_run_{run_id}.parquet"));
+        write_tag_file(&path, tags.iter())?;
+        tags.clear();
+        tag_runs.push(path);
+    }
+    *run_id += 1;
+    Ok(())
+}
+
+fn write_table_tag_file<'a>(
+    path: &Path,
+    rows: impl Iterator<Item = &'a TableTagKey>,
+) -> Result<usize> {
+    let rows: Vec<_> = rows.collect();
+    let mut writer = IndexWriter::try_new(path, IndexKind::TableTag.schema())?;
+    let batch = RecordBatch::try_new(
+        IndexKind::TableTag.schema(),
+        vec![
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|r| r.table_id).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|r| r.column_id).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(StringArray::from_iter_values(
+                rows.iter().map(|r| r.value.as_str()),
+            )) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    writer.write(&batch)?;
+    writer.close()
+}
+
+fn write_tag_file<'a>(path: &Path, rows: impl Iterator<Item = &'a TagKey>) -> Result<usize> {
+    let rows: Vec<_> = rows.collect();
+    let mut writer = IndexWriter::try_new(path, IndexKind::Tag.schema())?;
+    let batch = RecordBatch::try_new(
+        IndexKind::Tag.schema(),
+        vec![
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|r| r.column_id).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(StringArray::from_iter_values(
+                rows.iter().map(|r| r.value.as_str()),
+            )) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    writer.write(&batch)?;
+    writer.close()
+}
+
+fn merge_or_empty(kind: IndexKind, runs: &[PathBuf], output: &Path) -> Result<usize> {
+    if runs.is_empty() {
+        return IndexWriter::try_new(output, kind.schema())?.close();
+    }
+    merge_index_files(kind, runs, output)
+}
+
+fn external_error(error: impl std::fmt::Display, context: String) -> crate::error::Error {
+    let boxed = common_error::ext::BoxedError::new(common_error::ext::PlainError::new(
+        error.to_string(),
+        common_error::status_code::StatusCode::Unexpected,
+    ));
+    let result: std::result::Result<(), common_error::ext::BoxedError> = Err(boxed);
+    result
+        .context(crate::error::ExternalSnafu { context })
+        .unwrap_err()
+}

--- a/src/mito2/src/aggr_index/index_io.rs
+++ b/src/mito2/src/aggr_index/index_io.rs
@@ -1,0 +1,89 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+use std::fs::File;
+use std::path::Path;
+
+use datatypes::arrow::array::RecordBatchReader;
+use datatypes::arrow::datatypes::SchemaRef;
+use datatypes::arrow::record_batch::RecordBatch;
+use parquet::arrow::ArrowWriter;
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+use snafu::ResultExt;
+
+use crate::aggr_index::schema::{IndexKind, validate_schema};
+use crate::error::{Error, ExternalSnafu, Result};
+
+pub struct IndexWriter {
+    writer: ArrowWriter<File>,
+    rows: usize,
+}
+
+impl IndexWriter {
+    pub fn try_new(path: impl AsRef<Path>, schema: SchemaRef) -> Result<Self> {
+        let file = File::create(path.as_ref()).map_err(|e| {
+            external_error(e, format!("create index file {}", path.as_ref().display()))
+        })?;
+        let writer = ArrowWriter::try_new(file, schema, None)
+            .map_err(|e| external_error(e, "create parquet arrow writer".to_string()))?;
+        Ok(Self { writer, rows: 0 })
+    }
+
+    pub fn write(&mut self, batch: &RecordBatch) -> Result<()> {
+        self.rows += batch.num_rows();
+        self.writer
+            .write(batch)
+            .map_err(|e| external_error(e, "write index parquet batch".to_string()))
+    }
+
+    pub fn close(self) -> Result<usize> {
+        let rows = self.rows;
+        self.writer
+            .close()
+            .map_err(|e| external_error(e, "close index parquet writer".to_string()))?;
+        Ok(rows)
+    }
+}
+
+pub struct IndexReader {
+    inner: parquet::arrow::arrow_reader::ParquetRecordBatchReader,
+}
+
+impl IndexReader {
+    pub fn try_new(path: impl AsRef<Path>, kind: IndexKind) -> Result<Self> {
+        let file = File::open(path.as_ref()).map_err(|e| {
+            external_error(e, format!("open index file {}", path.as_ref().display()))
+        })?;
+        let builder = ParquetRecordBatchReaderBuilder::try_new(file)
+            .map_err(|e| external_error(e, "open parquet record batch reader".to_string()))?;
+        validate_schema(kind, builder.schema().as_ref())?;
+        let inner = builder
+            .build()
+            .map_err(|e| external_error(e, "build parquet record batch reader".to_string()))?;
+        Ok(Self { inner })
+    }
+
+    pub fn schema(&self) -> SchemaRef {
+        self.inner.schema()
+    }
+}
+
+impl Iterator for IndexReader {
+    type Item = Result<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|r| r.map_err(|e| external_error(e, "read index parquet batch".to_string())))
+    }
+}
+
+fn external_error(error: impl std::fmt::Display, context: String) -> Error {
+    let boxed = common_error::ext::BoxedError::new(common_error::ext::PlainError::new(
+        error.to_string(),
+        common_error::status_code::StatusCode::Unexpected,
+    ));
+    let result: std::result::Result<(), common_error::ext::BoxedError> = Err(boxed);
+    result.context(ExternalSnafu { context }).unwrap_err()
+}

--- a/src/mito2/src/aggr_index/input.rs
+++ b/src/mito2/src/aggr_index/input.rs
@@ -1,0 +1,130 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+use std::sync::Arc;
+
+use datatypes::arrow::datatypes::SchemaRef;
+use futures::stream;
+use object_store::ObjectStore;
+use snafu::{OptionExt, ensure};
+use store_api::codec::PrimaryKeyEncoding;
+use store_api::metadata::RegionMetadataRef;
+use store_api::region_request::PathType;
+
+use crate::error::{InvalidMetaSnafu, Result};
+use crate::read::BoxedRecordBatchStream;
+use crate::read::flat_merge::FlatMergeReader;
+use crate::read::read_columns::ReadColumns;
+use crate::sst::file::{FileHandle, FileMeta};
+use crate::sst::file_purger::NoopFilePurger;
+use crate::sst::parquet::DEFAULT_READ_BATCH_SIZE;
+use crate::sst::parquet::flat_format::FlatReadFormat;
+use crate::sst::parquet::reader::ParquetReaderBuilder;
+
+pub struct SstStream {
+    pub stream: BoxedRecordBatchStream,
+    pub metadata: RegionMetadataRef,
+    pub schema: SchemaRef,
+}
+
+pub async fn open_sst_stream(
+    table_dir: String,
+    path_type: PathType,
+    object_store: ObjectStore,
+    file_meta: FileMeta,
+) -> Result<SstStream> {
+    let handle = FileHandle::new(file_meta, Arc::new(NoopFilePurger));
+    let file_path = handle.file_path(&table_dir, path_type);
+    let reader = ParquetReaderBuilder::new(table_dir, path_type, handle, object_store)
+        .projection(Some(ReadColumns::from_deduped_column_ids(
+            std::iter::empty(),
+        )))
+        .build()
+        .await?
+        .context(InvalidMetaSnafu {
+            reason: "SST has no readable row groups",
+        })?;
+    let metadata = reader.metadata().clone();
+    validate_sparse_flat_metadata(&metadata)?;
+    reject_legacy_format(
+        &metadata,
+        reader
+            .parquet_metadata()
+            .file_metadata()
+            .schema_descr()
+            .num_columns(),
+        &file_path,
+    )?;
+    let mut reader = reader;
+    let first = reader.next_record_batch().await?;
+    let schema = if let Some(batch) = &first {
+        batch.schema()
+    } else {
+        metadata.schema.arrow_schema().clone()
+    };
+    let stream = Box::pin(stream::try_unfold(
+        (first, reader),
+        |(pending, mut reader)| async move {
+            if let Some(batch) = pending {
+                return Ok(Some((batch, (None, reader))));
+            }
+            let batch = reader.next_record_batch().await?;
+            Ok(batch.map(|batch| (batch, (None, reader))))
+        },
+    ));
+    Ok(SstStream {
+        stream,
+        metadata,
+        schema,
+    })
+}
+
+pub fn validate_sparse_flat_metadata(metadata: &RegionMetadataRef) -> Result<()> {
+    ensure!(
+        metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse,
+        InvalidMetaSnafu {
+            reason: "aggregate index only supports sparse primary-key encoding"
+        }
+    );
+    Ok(())
+}
+
+pub fn reject_legacy_format(
+    metadata: &RegionMetadataRef,
+    num_columns: usize,
+    file_path: &str,
+) -> Result<()> {
+    let legacy = FlatReadFormat::is_legacy_format(metadata, num_columns, file_path)?;
+    ensure!(
+        !legacy,
+        InvalidMetaSnafu {
+            reason: format!("legacy primary-key SST format is not supported: {file_path}")
+        }
+    );
+    Ok(())
+}
+
+pub async fn merge_sources(
+    schema: SchemaRef,
+    sources: Vec<BoxedRecordBatchStream>,
+) -> Result<BoxedRecordBatchStream> {
+    let reader = FlatMergeReader::new(schema, sources, DEFAULT_READ_BATCH_SIZE, None).await?;
+    Ok(Box::pin(stream::try_unfold(
+        reader,
+        |mut reader| async move {
+            let batch = reader.next_batch().await?;
+            Ok(batch.map(|batch| (batch, reader)))
+        },
+    )))
+}
+
+pub fn validate_same_schema(expected: &SchemaRef, actual: &SchemaRef) -> Result<()> {
+    ensure!(
+        expected.as_ref() == actual.as_ref(),
+        InvalidMetaSnafu {
+            reason: "mixed sparse-flat SST schemas are not supported"
+        }
+    );
+    Ok(())
+}

--- a/src/mito2/src/aggr_index/merge.rs
+++ b/src/mito2/src/aggr_index/merge.rs
@@ -1,0 +1,189 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use datatypes::arrow::array::{
+    Array, BinaryArray, Int64Array, StringArray, UInt32Array, UInt64Array,
+};
+use datatypes::arrow::record_batch::RecordBatch;
+use snafu::{OptionExt, ResultExt};
+
+use crate::aggr_index::index_io::{IndexReader, IndexWriter};
+use crate::aggr_index::schema::IndexKind;
+use crate::error::{InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result};
+
+pub fn merge_index_files(
+    kind: IndexKind,
+    inputs: &[impl AsRef<Path>],
+    output: impl AsRef<Path>,
+) -> Result<usize> {
+    match kind {
+        IndexKind::Pk => merge_pk(inputs, output),
+        IndexKind::TableTag => merge_table_tag(inputs, output),
+        IndexKind::Tag => merge_tag(inputs, output),
+    }
+}
+
+fn merge_pk(inputs: &[impl AsRef<Path>], output: impl AsRef<Path>) -> Result<usize> {
+    let mut map: BTreeMap<Vec<u8>, (i64, i64, u64)> = BTreeMap::new();
+    for input in inputs {
+        let mut reader = IndexReader::try_new(input, IndexKind::Pk)?;
+        for batch in &mut reader {
+            let batch = batch?;
+            let pk = binary_col(&batch, 0)?;
+            let min = int64_col(&batch, 1)?;
+            let max = int64_col(&batch, 2)?;
+            let cnt = u64_col(&batch, 3)?;
+            for row in 0..batch.num_rows() {
+                let e = map
+                    .entry(pk.value(row).to_vec())
+                    .or_insert((i64::MAX, i64::MIN, 0));
+                e.0 = e.0.min(min.value(row));
+                e.1 = e.1.max(max.value(row));
+                e.2 += cnt.value(row);
+            }
+        }
+    }
+    let mut writer = IndexWriter::try_new(output, IndexKind::Pk.schema())?;
+    let rows: Vec<_> = map.into_iter().collect();
+    let batch = RecordBatch::try_new(
+        IndexKind::Pk.schema(),
+        vec![
+            Arc::new(BinaryArray::from_iter_values(
+                rows.iter().map(|(k, _)| k.as_slice()),
+            )) as _,
+            Arc::new(Int64Array::from(
+                rows.iter().map(|(_, v)| v.0).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(Int64Array::from(
+                rows.iter().map(|(_, v)| v.1).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(UInt64Array::from(
+                rows.iter().map(|(_, v)| v.2).collect::<Vec<_>>(),
+            )) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    writer.write(&batch)?;
+    writer.close()
+}
+
+fn merge_table_tag(inputs: &[impl AsRef<Path>], output: impl AsRef<Path>) -> Result<usize> {
+    let mut set = BTreeMap::<(u32, u32, String), ()>::new();
+    for input in inputs {
+        let mut reader = IndexReader::try_new(input, IndexKind::TableTag)?;
+        for batch in &mut reader {
+            let batch = batch?;
+            let table = u32_col(&batch, 0)?;
+            let col = u32_col(&batch, 1)?;
+            let val = string_col(&batch, 2)?;
+            for row in 0..batch.num_rows() {
+                set.insert(
+                    (table.value(row), col.value(row), val.value(row).to_string()),
+                    (),
+                );
+            }
+        }
+    }
+    let rows: Vec<_> = set.into_keys().collect();
+    let mut writer = IndexWriter::try_new(output, IndexKind::TableTag.schema())?;
+    let batch = RecordBatch::try_new(
+        IndexKind::TableTag.schema(),
+        vec![
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(StringArray::from_iter_values(
+                rows.iter().map(|r| r.2.as_str()),
+            )) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    writer.write(&batch)?;
+    writer.close()
+}
+
+fn merge_tag(inputs: &[impl AsRef<Path>], output: impl AsRef<Path>) -> Result<usize> {
+    let mut set = BTreeMap::<(u32, String), ()>::new();
+    for input in inputs {
+        let mut reader = IndexReader::try_new(input, IndexKind::Tag)?;
+        for batch in &mut reader {
+            let batch = batch?;
+            let col = u32_col(&batch, 0)?;
+            let val = string_col(&batch, 1)?;
+            for row in 0..batch.num_rows() {
+                set.insert((col.value(row), val.value(row).to_string()), ());
+            }
+        }
+    }
+    let rows: Vec<_> = set.into_keys().collect();
+    let mut writer = IndexWriter::try_new(output, IndexKind::Tag.schema())?;
+    let batch = RecordBatch::try_new(
+        IndexKind::Tag.schema(),
+        vec![
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(StringArray::from_iter_values(
+                rows.iter().map(|r| r.1.as_str()),
+            )) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    writer.write(&batch)?;
+    writer.close()
+}
+
+fn binary_col(batch: &RecordBatch, idx: usize) -> Result<&BinaryArray> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not Binary"),
+        })
+}
+fn int64_col(batch: &RecordBatch, idx: usize) -> Result<&Int64Array> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not Int64"),
+        })
+}
+fn u64_col(batch: &RecordBatch, idx: usize) -> Result<&UInt64Array> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not UInt64"),
+        })
+}
+fn u32_col(batch: &RecordBatch, idx: usize) -> Result<&UInt32Array> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not UInt32"),
+        })
+}
+
+fn string_col(batch: &RecordBatch, idx: usize) -> Result<&StringArray> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not Utf8"),
+        })
+}

--- a/src/mito2/src/aggr_index/mod.rs
+++ b/src/mito2/src/aggr_index/mod.rs
@@ -1,0 +1,16 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+//! Standalone aggregate index POC for sparse-flat SSTs.
+
+pub mod builder;
+pub mod index_io;
+pub mod input;
+pub mod merge;
+pub mod schema;
+
+pub use builder::{BuildOutput, build_indexes};
+pub use index_io::{IndexReader, IndexWriter};
+pub use merge::merge_index_files;
+pub use schema::IndexKind;

--- a/src/mito2/src/aggr_index/schema.rs
+++ b/src/mito2/src/aggr_index/schema.rs
@@ -1,0 +1,80 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+use std::sync::Arc;
+
+use datatypes::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use store_api::storage::ColumnId;
+use store_api::storage::consts::ReservedColumnId;
+
+pub const PRIMARY_KEY_COL: &str = "__primary_key";
+pub const MIN_TS_COL: &str = "min_ts";
+pub const MAX_TS_COL: &str = "max_ts";
+pub const ROW_COUNT_COL: &str = "row_count";
+pub const TABLE_ID_COL: &str = "__table_id";
+pub const COLUMN_ID_COL: &str = "column_id";
+pub const TAG_VALUE_COL: &str = "tag_value";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexKind {
+    Pk,
+    TableTag,
+    Tag,
+}
+
+impl IndexKind {
+    pub fn schema(self) -> SchemaRef {
+        match self {
+            IndexKind::Pk => pk_schema(),
+            IndexKind::TableTag => table_tag_schema(),
+            IndexKind::Tag => tag_schema(),
+        }
+    }
+
+    pub fn file_name(self) -> &'static str {
+        match self {
+            IndexKind::Pk => "pk.parquet",
+            IndexKind::TableTag => "table_tag.parquet",
+            IndexKind::Tag => "tag.parquet",
+        }
+    }
+}
+
+pub fn pk_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new(PRIMARY_KEY_COL, DataType::Binary, false),
+        Field::new(MIN_TS_COL, DataType::Int64, false),
+        Field::new(MAX_TS_COL, DataType::Int64, false),
+        Field::new(ROW_COUNT_COL, DataType::UInt64, false),
+    ]))
+}
+
+pub fn table_tag_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new(TABLE_ID_COL, DataType::UInt32, false),
+        Field::new(COLUMN_ID_COL, DataType::UInt32, false),
+        Field::new(TAG_VALUE_COL, DataType::Utf8, false),
+    ]))
+}
+
+pub fn tag_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new(COLUMN_ID_COL, DataType::UInt32, false),
+        Field::new(TAG_VALUE_COL, DataType::Utf8, false),
+    ]))
+}
+
+pub fn validate_schema(kind: IndexKind, schema: &Schema) -> crate::error::Result<()> {
+    if schema != kind.schema().as_ref() {
+        return crate::error::InvalidMetaSnafu {
+            reason: format!("invalid {:?} index schema: {schema:?}", kind),
+        }
+        .fail();
+    }
+    Ok(())
+}
+
+pub fn is_reserved_tag_column(column_id: ColumnId) -> bool {
+    column_id == ReservedColumnId::table_id() || column_id == ReservedColumnId::tsid()
+}

--- a/src/mito2/src/lib.rs
+++ b/src/mito2/src/lib.rs
@@ -25,6 +25,7 @@
 pub mod test_util;
 
 pub mod access_layer;
+pub mod aggr_index;
 pub mod cache;
 pub mod compaction;
 pub mod config;


### PR DESCRIPTION
### Motivation

- Introduce a standalone proof-of-concept for aggregate index generation/inspection for sparse-flat SSTs to support indexing and inspection workflows. 
- Provide a CLI utility under the datanode to build, merge, and read aggregate index files from SST inputs. 
- Expose necessary helpers from existing bench code to reuse object-store and path/region parsing logic.

### Description

- Add a new `mito2::aggr_index` module with submodules `builder`, `index_io`, `input`, `merge`, and `schema` that implement index building, reading/writing Parquet index files, input streaming from SSTs, merging of partial runs, and index schema definitions (new files `src/mito2/src/aggr_index/*`).
- Add a datanode CLI command `AggrIndex` implemented in `src/cmd/src/datanode/aggr_index.rs` to `build`, `merge`, and `read` aggregate index files, and wire it into the top-level datanode CLI (`datanode.rs`) and the greptime binary (`greptime.rs`).
- Export parsing helpers from `scanbench` (`parse_region_id` and `parse_path_type`) as `pub(super)` and reuse object-store config parsing from `objbench` to build the `AggrIndex` CLI flows.
- Update workspace manifests to include the `hex` crate (`src/cmd/Cargo.toml` and `Cargo.lock`) which is used for decoding primary key hex strings in the `read` subcommand.

### Testing

- Ran `cargo build` for the workspace to validate integration of new modules and the CLI and the build completed successfully. 
- Executed unit tests for the modified crates with `cargo test -p mito2` and `cargo test -p cmd`, and the test suites completed successfully. 
- Performed a local smoke run of the datanode `AggrIndex` subcommands to verify basic `build`, `merge`, and `read` execution paths (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26f4c3caf88329a914a5e139f66d44)