### PR TITLE
feat: expand aggregate index PK formats and add pk->derived transform

### DIFF
--- a/src/cmd/src/datanode/aggr_index.rs
+++ b/src/cmd/src/datanode/aggr_index.rs
@@ -6,11 +6,15 @@ use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand, ValueEnum};
 use colored::Colorize;
-use datatypes::arrow::array::{BinaryArray, Int64Array, StringArray, UInt32Array, UInt64Array};
+use datatypes::arrow::array::{
+    Array, BinaryArray, Int64Array, MapArray, StringArray, UInt32Array, UInt64Array,
+};
 use futures::StreamExt;
 use mito2::aggr_index::index_io::IndexReader;
 use mito2::aggr_index::input::{merge_sources, open_sst_stream, validate_same_schema};
-use mito2::aggr_index::{IndexKind, build_indexes, merge_index_files};
+use mito2::aggr_index::{
+    IndexKind, TransformFormat, build_indexes, merge_index_files, transform_pk_index,
+};
 use mito2::sst::file::{FileMeta, RegionFileId};
 use object_store::ObjectStore;
 use object_store::services::Fs;
@@ -32,6 +36,7 @@ enum AggrIndexSubCommand {
     Build(BuildCommand),
     Merge(MergeCommand),
     Read(ReadCommand),
+    TransformPk(TransformPkCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -63,6 +68,26 @@ struct MergeCommand {
 }
 
 #[derive(Debug, Parser)]
+struct TransformPkCommand {
+    #[clap(long, value_name = "FILE")]
+    config: PathBuf,
+    #[clap(long)]
+    table_dir: String,
+    #[clap(long, default_value = "bare")]
+    path_type: String,
+    #[clap(long)]
+    region_id: String,
+    #[clap(long)]
+    input: String,
+    #[clap(long)]
+    pk_input: PathBuf,
+    #[clap(long)]
+    output_dir: PathBuf,
+    #[clap(long, value_enum)]
+    format: Vec<CliTransformFormat>,
+}
+
+#[derive(Debug, Parser)]
 struct ReadCommand {
     #[clap(long, value_enum)]
     kind: CliKind,
@@ -83,6 +108,9 @@ enum CliKind {
     Pk,
     TableTag,
     Tag,
+    TableTagTsid,
+    PkMap,
+    PkColumns,
 }
 impl From<CliKind> for IndexKind {
     fn from(v: CliKind) -> Self {
@@ -90,6 +118,26 @@ impl From<CliKind> for IndexKind {
             CliKind::Pk => IndexKind::Pk,
             CliKind::TableTag => IndexKind::TableTag,
             CliKind::Tag => IndexKind::Tag,
+            CliKind::TableTagTsid => IndexKind::TableTagTsid,
+            CliKind::PkMap => IndexKind::PkMap,
+            CliKind::PkColumns => IndexKind::PkColumns,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum CliTransformFormat {
+    TableTagTsid,
+    Map,
+    Columns,
+}
+
+impl From<CliTransformFormat> for TransformFormat {
+    fn from(v: CliTransformFormat) -> Self {
+        match v {
+            CliTransformFormat::TableTagTsid => TransformFormat::TableTagTsid,
+            CliTransformFormat::Map => TransformFormat::PkMap,
+            CliTransformFormat::Columns => TransformFormat::PkColumns,
         }
     }
 }
@@ -100,6 +148,7 @@ impl AggrIndexCommand {
             AggrIndexSubCommand::Build(cmd) => cmd.run().await,
             AggrIndexSubCommand::Merge(cmd) => cmd.run().await,
             AggrIndexSubCommand::Read(cmd) => cmd.run().await,
+            AggrIndexSubCommand::TransformPk(cmd) => cmd.run().await,
         }
     }
 }
@@ -203,6 +252,85 @@ impl BuildCommand {
             output.table_tag_rows,
         )?;
         print_file("tag", &self.output_dir.join("tag.parquet"), output.tag_rows)?;
+        println!(
+            "costs: sst_iter_decode_collect={:?} legacy_pk_write={:?} table_tag_run_write={:?} tag_run_write={:?} table_tag_merge_final_write={:?} tag_merge_final_write={:?}",
+            output.costs.sst_iteration_decode_collect,
+            output.costs.legacy_pk_write,
+            output.costs.table_tag_run_write,
+            output.costs.tag_run_write,
+            output.costs.table_tag_merge_final_write,
+            output.costs.tag_merge_final_write
+        );
+        Ok(())
+    }
+}
+
+impl TransformPkCommand {
+    async fn run(&self) -> error::Result<()> {
+        let (store_cfg, _, _) = parse_config(&self.config)?;
+        let object_store = build_object_store(&store_cfg).await?;
+        let region_id = parse_region_id(&self.region_id)?;
+        let path_type = parse_path_type(&self.path_type)?;
+        let file_id = parse_file_id(&self.input)?;
+        let path = sst_path(&self.table_dir, region_id, path_type, file_id);
+        let stat = object_store.stat(&path).await.map_err(|e| {
+            error::IllegalConfigSnafu {
+                msg: format!("stat {path} failed: {e}"),
+            }
+            .build()
+        })?;
+        let file_meta = FileMeta {
+            region_id,
+            file_id,
+            file_size: stat.content_length(),
+            ..Default::default()
+        };
+        let sst = open_sst_stream(self.table_dir.clone(), path_type, object_store, file_meta)
+            .await
+            .map_err(to_cmd_err)?;
+        let index_store = local_fs_store()?;
+        let pk_input = store_path(&self.pk_input)?;
+        let output_dir = store_path(&self.output_dir)?;
+        let formats = self
+            .format
+            .iter()
+            .copied()
+            .map(TransformFormat::from)
+            .collect::<Vec<_>>();
+        let output =
+            transform_pk_index(sst.metadata, index_store, &pk_input, &output_dir, &formats)
+                .await
+                .map_err(to_cmd_err)?;
+
+        if output.table_tag_tsid_path.is_some() {
+            print_file(
+                "table-tag-tsid",
+                &self.output_dir.join("table_tag_tsid.parquet"),
+                output.table_tag_tsid_rows,
+            )?;
+        }
+        if output.pk_map_path.is_some() {
+            print_file(
+                "pk-map",
+                &self.output_dir.join("pk_map.parquet"),
+                output.pk_map_rows,
+            )?;
+        }
+        if output.pk_columns_path.is_some() {
+            print_file(
+                "pk-columns",
+                &self.output_dir.join("pk_columns.parquet"),
+                output.pk_columns_rows,
+            )?;
+        }
+        println!(
+            "costs: old_pk_read_iter={:?} pk_decode_tag_extract={:?} table_tag_tsid_write={:?} pk_map_write={:?} pk_columns_write={:?}",
+            output.costs.read_iteration,
+            output.costs.decode_transform,
+            output.costs.table_tag_tsid_write,
+            output.costs.pk_map_write,
+            output.costs.pk_columns_write
+        );
         Ok(())
     }
 }
@@ -251,6 +379,11 @@ impl ReadCommand {
                     print_table_tag(&batch, self.table_id, self.column_id, tag_value)?
                 }
                 IndexKind::Tag => print_tag(&batch, self.column_id, tag_value)?,
+                IndexKind::TableTagTsid => {
+                    print_table_tag_tsid(&batch, self.table_id, self.column_id, tag_value)?
+                }
+                IndexKind::PkMap => print_pk_map(&batch, primary_key.as_deref())?,
+                IndexKind::PkColumns => print_pk_columns(&batch, primary_key.as_deref())?,
             }
         }
         Ok(())
@@ -302,6 +435,136 @@ fn print_table_tag(
     }
     Ok(())
 }
+fn print_table_tag_tsid(
+    batch: &datatypes::arrow::record_batch::RecordBatch,
+    table_filter: Option<u32>,
+    col_filter: Option<u32>,
+    val_filter: Option<&str>,
+) -> error::Result<()> {
+    let t = col::<UInt32Array>(batch, 0)?;
+    let c = col::<UInt32Array>(batch, 1)?;
+    let v = col::<StringArray>(batch, 2)?;
+    let tsid = col::<UInt64Array>(batch, 3)?;
+    for i in 0..batch.num_rows() {
+        if table_filter.is_none_or(|x| x == t.value(i))
+            && col_filter.is_none_or(|x| x == c.value(i))
+            && val_filter.is_none_or(|x| x == v.value(i))
+        {
+            println!(
+                "table_id={} column_id={} tag_value={} tsid={}",
+                t.value(i),
+                c.value(i),
+                v.value(i),
+                tsid.value(i)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn print_pk_map(
+    batch: &datatypes::arrow::record_batch::RecordBatch,
+    filter: Option<&[u8]>,
+) -> error::Result<()> {
+    let pk = col::<BinaryArray>(batch, 0)?;
+    let min = col::<Int64Array>(batch, 1)?;
+    let max = col::<Int64Array>(batch, 2)?;
+    let cnt = col::<UInt64Array>(batch, 3)?;
+    let table = col::<UInt32Array>(batch, 4)?;
+    let tsid = col::<UInt64Array>(batch, 5)?;
+    let tags = col::<MapArray>(batch, 6)?;
+    for i in 0..batch.num_rows() {
+        if filter.is_none_or(|f| f == pk.value(i)) {
+            println!(
+                "pk={} min_ts={} max_ts={} row_count={} table_id={} tsid={} tags={}",
+                hex::encode(pk.value(i)),
+                min.value(i),
+                max.value(i),
+                cnt.value(i),
+                table.value(i),
+                tsid.value(i),
+                format_map(tags, i)?
+            );
+        }
+    }
+    Ok(())
+}
+
+fn print_pk_columns(
+    batch: &datatypes::arrow::record_batch::RecordBatch,
+    filter: Option<&[u8]>,
+) -> error::Result<()> {
+    let pk = col::<BinaryArray>(batch, 0)?;
+    let min = col::<Int64Array>(batch, 1)?;
+    let max = col::<Int64Array>(batch, 2)?;
+    let cnt = col::<UInt64Array>(batch, 3)?;
+    let table = col::<UInt32Array>(batch, 4)?;
+    let tsid = col::<UInt64Array>(batch, 5)?;
+    for i in 0..batch.num_rows() {
+        if filter.is_none_or(|f| f == pk.value(i)) {
+            let mut tags = Vec::new();
+            for idx in 6..batch.num_columns() {
+                let array = col::<StringArray>(batch, idx)?;
+                if array.is_null(i) {
+                    tags.push(format!("{}=NULL", batch.schema().field(idx).name()));
+                } else {
+                    tags.push(format!(
+                        "{}={}",
+                        batch.schema().field(idx).name(),
+                        array.value(i)
+                    ));
+                }
+            }
+            println!(
+                "pk={} min_ts={} max_ts={} row_count={} table_id={} tsid={} {}",
+                hex::encode(pk.value(i)),
+                min.value(i),
+                max.value(i),
+                cnt.value(i),
+                table.value(i),
+                tsid.value(i),
+                tags.join(" ")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn format_map(tags: &MapArray, row: usize) -> error::Result<String> {
+    let entries = tags.value(row);
+    let keys = entries
+        .as_any()
+        .downcast_ref::<datatypes::arrow::array::StructArray>()
+        .context(error::IllegalConfigSnafu {
+            msg: "invalid map entries".to_string(),
+        })?
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .context(error::IllegalConfigSnafu {
+            msg: "invalid map key column".to_string(),
+        })?
+        .clone();
+    let values = entries
+        .as_any()
+        .downcast_ref::<datatypes::arrow::array::StructArray>()
+        .context(error::IllegalConfigSnafu {
+            msg: "invalid map entries".to_string(),
+        })?
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context(error::IllegalConfigSnafu {
+            msg: "invalid map value column".to_string(),
+        })?
+        .clone();
+    let mut parts = Vec::new();
+    for i in 0..entries.len() {
+        parts.push(format!("{}={}", keys.value(i), values.value(i)));
+    }
+    Ok(format!("{{{}}}", parts.join(",")))
+}
+
 fn print_tag(
     batch: &datatypes::arrow::record_batch::RecordBatch,
     col_filter: Option<u32>,

--- a/src/mito2/src/aggr_index/builder.rs
+++ b/src/mito2/src/aggr_index/builder.rs
@@ -5,6 +5,7 @@
 use std::collections::BTreeSet;
 use std::mem;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use datatypes::arrow::array::{
     Array, BinaryArray, DictionaryArray, Int64Array, StringArray, UInt32Array, UInt64Array,
@@ -28,6 +29,16 @@ use crate::sst::parquet::flat_format::{primary_key_column_index, time_index_colu
 
 const PK_WRITE_BUFFER_ROWS: usize = 1024;
 
+#[derive(Debug, Clone, Default)]
+pub struct BuildCosts {
+    pub sst_iteration_decode_collect: Duration,
+    pub legacy_pk_write: Duration,
+    pub table_tag_run_write: Duration,
+    pub tag_run_write: Duration,
+    pub table_tag_merge_final_write: Duration,
+    pub tag_merge_final_write: Duration,
+}
+
 #[derive(Debug, Clone)]
 pub struct BuildOutput {
     pub pk_path: String,
@@ -36,6 +47,7 @@ pub struct BuildOutput {
     pub pk_rows: usize,
     pub table_tag_rows: usize,
     pub tag_rows: usize,
+    pub costs: BuildCosts,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -79,6 +91,8 @@ pub async fn build_indexes(
     let tag_path = format!("{output_dir}/{}", IndexKind::Tag.file_name());
     let mut pk_writer =
         IndexWriter::try_new(&object_store, &pk_path, IndexKind::Pk.schema()).await?;
+    let mut costs = BuildCosts::default();
+    let iteration_start = Instant::now();
     let codec = build_primary_key_codec(&metadata);
 
     let mut current_pk: Option<Vec<u8>> = None;
@@ -133,6 +147,7 @@ pub async fn build_indexes(
                         &mut table_tag_runs,
                         &mut tag_runs,
                         &mut run_id,
+                        &mut costs,
                     )
                     .await?;
                     tag_buffer_bytes = 0;
@@ -155,8 +170,11 @@ pub async fn build_indexes(
         .await?;
         pk_rows += 1;
     }
+    costs.sst_iteration_decode_collect = iteration_start.elapsed();
+    let pk_write_start = Instant::now();
     flush_pk_rows(&mut pk_writer, &mut pk_buffer).await?;
     pk_writer.close().await?;
+    costs.legacy_pk_write += pk_write_start.elapsed();
     flush_runs(
         &object_store,
         output_dir,
@@ -165,9 +183,11 @@ pub async fn build_indexes(
         &mut table_tag_runs,
         &mut tag_runs,
         &mut run_id,
+        &mut costs,
     )
     .await?;
 
+    let table_tag_merge_start = Instant::now();
     let table_tag_rows = merge_or_empty(
         IndexKind::TableTag,
         &object_store,
@@ -175,7 +195,10 @@ pub async fn build_indexes(
         &table_tag_path,
     )
     .await?;
+    costs.table_tag_merge_final_write = table_tag_merge_start.elapsed();
+    let tag_merge_start = Instant::now();
     let tag_rows = merge_or_empty(IndexKind::Tag, &object_store, &tag_runs, &tag_path).await?;
+    costs.tag_merge_final_write = tag_merge_start.elapsed();
     for path in table_tag_runs.into_iter().chain(tag_runs) {
         let _ = object_store.delete(&path).await;
     }
@@ -187,6 +210,7 @@ pub async fn build_indexes(
         pk_rows,
         table_tag_rows,
         tag_rows,
+        costs,
     })
 }
 
@@ -361,16 +385,21 @@ async fn flush_runs(
     table_tag_runs: &mut Vec<String>,
     tag_runs: &mut Vec<String>,
     run_id: &mut usize,
+    costs: &mut BuildCosts,
 ) -> Result<()> {
     if !table_tags.is_empty() {
         let path = format!("{output_dir}/.table_tag_run_{run_id}.parquet");
+        let start = Instant::now();
         write_table_tag_file(object_store, &path, table_tags.iter()).await?;
+        costs.table_tag_run_write += start.elapsed();
         table_tags.clear();
         table_tag_runs.push(path);
     }
     if !tags.is_empty() {
         let path = format!("{output_dir}/.tag_run_{run_id}.parquet");
+        let start = Instant::now();
         write_tag_file(object_store, &path, tags.iter()).await?;
+        costs.tag_run_write += start.elapsed();
         tags.clear();
         tag_runs.push(path);
     }

--- a/src/mito2/src/aggr_index/merge.rs
+++ b/src/mito2/src/aggr_index/merge.rs
@@ -21,11 +21,11 @@ use datatypes::arrow::datatypes::SchemaRef;
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::{Stream, StreamExt};
 use object_store::ObjectStore;
-use snafu::{OptionExt, ResultExt};
+use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::aggr_index::index_io::{IndexReader, IndexWriter};
 use crate::aggr_index::schema::IndexKind;
-use crate::error::{InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result};
+use crate::error::{InvalidMetaSnafu, InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result};
 
 const MERGE_BATCH_SIZE: usize = 8192;
 
@@ -35,6 +35,12 @@ pub async fn merge_index_files(
     inputs: &[String],
     output: &str,
 ) -> Result<usize> {
+    ensure!(
+        kind != IndexKind::PkColumns,
+        InvalidMetaSnafu {
+            reason: "PkColumns has a dynamic metadata-derived schema and cannot be generically merged"
+        }
+    );
     if inputs.is_empty() {
         return IndexWriter::try_new(object_store, output, kind.schema())
             .await?
@@ -47,6 +53,9 @@ pub async fn merge_index_files(
         IndexKind::Pk => merge_pk(merged, object_store, output).await,
         IndexKind::TableTag => merge_table_tag(merged, object_store, output).await,
         IndexKind::Tag => merge_tag(merged, object_store, output).await,
+        IndexKind::TableTagTsid => merge_table_tag_tsid(merged, object_store, output).await,
+        IndexKind::PkMap => merge_passthrough(kind, merged, object_store, output).await,
+        IndexKind::PkColumns => unreachable!("PkColumns merge is rejected above"),
     }
 }
 
@@ -85,6 +94,9 @@ fn sort_ordering(kind: IndexKind, schema: SchemaRef) -> LexOrdering {
         IndexKind::Pk => 1,
         IndexKind::TableTag => 3,
         IndexKind::Tag => 2,
+        IndexKind::TableTagTsid => 4,
+        IndexKind::PkMap => 1,
+        IndexKind::PkColumns => unreachable!("PkColumns merge is rejected before sorting"),
     };
     LexOrdering::new((0..columns).map(|idx| {
         PhysicalSortExpr::new(
@@ -197,6 +209,76 @@ async fn merge_tag(
         }
     }
     buffer.flush(&mut writer).await?;
+    writer.close().await
+}
+
+async fn merge_table_tag_tsid(
+    mut merged: SendableRecordBatchStream,
+    object_store: &ObjectStore,
+    output: &str,
+) -> Result<usize> {
+    let mut writer =
+        IndexWriter::try_new(object_store, output, IndexKind::TableTagTsid.schema()).await?;
+    let mut last: Option<(u32, u32, String, u64)> = None;
+
+    while let Some(batch) = merged.next().await {
+        let batch = batch.map_err(|e| {
+            external_error(e, "merge aggregate table-tag-tsid index stream".to_string())
+        })?;
+        let table = u32_col(&batch, 0)?;
+        let col = u32_col(&batch, 1)?;
+        let val = string_col(&batch, 2)?;
+        let tsid = u64_col(&batch, 3)?;
+        let mut rows = Vec::new();
+        for row in 0..batch.num_rows() {
+            let key = (
+                table.value(row),
+                col.value(row),
+                val.value(row).to_string(),
+                tsid.value(row),
+            );
+            if last.as_ref() != Some(&key) {
+                last = Some(key.clone());
+                rows.push(key);
+            }
+        }
+        if !rows.is_empty() {
+            let out = RecordBatch::try_new(
+                IndexKind::TableTagTsid.schema(),
+                vec![
+                    Arc::new(UInt32Array::from(
+                        rows.iter().map(|r| r.0).collect::<Vec<_>>(),
+                    )) as _,
+                    Arc::new(UInt32Array::from(
+                        rows.iter().map(|r| r.1).collect::<Vec<_>>(),
+                    )) as _,
+                    Arc::new(StringArray::from_iter_values(
+                        rows.iter().map(|r| r.2.as_str()),
+                    )) as _,
+                    Arc::new(UInt64Array::from(
+                        rows.iter().map(|r| r.3).collect::<Vec<_>>(),
+                    )) as _,
+                ],
+            )
+            .context(NewRecordBatchSnafu)?;
+            writer.write(&out).await?;
+        }
+    }
+    writer.close().await
+}
+
+async fn merge_passthrough(
+    kind: IndexKind,
+    mut merged: SendableRecordBatchStream,
+    object_store: &ObjectStore,
+    output: &str,
+) -> Result<usize> {
+    let mut writer = IndexWriter::try_new(object_store, output, kind.schema()).await?;
+    while let Some(batch) = merged.next().await {
+        let batch = batch
+            .map_err(|e| external_error(e, format!("merge aggregate {kind:?} index stream")))?;
+        writer.write(&batch).await?;
+    }
     writer.close().await
 }
 

--- a/src/mito2/src/aggr_index/merge.rs
+++ b/src/mito2/src/aggr_index/merge.rs
@@ -15,16 +15,18 @@ use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSe
 use datafusion::physical_plan::sorts::streaming_merge::StreamingMergeBuilder;
 use datafusion::physical_plan::{RecordBatchStream, SendableRecordBatchStream};
 use datatypes::arrow::array::{
-    Array, BinaryArray, Int64Array, StringArray, UInt32Array, UInt64Array,
+    Array, ArrayRef, BinaryArray, Int64Array, MapArray, StringArray, StructArray, UInt32Array,
+    UInt64Array,
 };
-use datatypes::arrow::datatypes::SchemaRef;
+use datatypes::arrow::buffer::OffsetBuffer;
+use datatypes::arrow::datatypes::{DataType, Field, SchemaRef};
 use datatypes::arrow::record_batch::RecordBatch;
 use futures::{Stream, StreamExt};
 use object_store::ObjectStore;
 use snafu::{OptionExt, ResultExt, ensure};
 
 use crate::aggr_index::index_io::{IndexReader, IndexWriter};
-use crate::aggr_index::schema::IndexKind;
+use crate::aggr_index::schema::{IndexKind, MAP_KEY_FIELD, MAP_VALUE_FIELD};
 use crate::error::{InvalidMetaSnafu, InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result};
 
 const MERGE_BATCH_SIZE: usize = 8192;
@@ -54,7 +56,7 @@ pub async fn merge_index_files(
         IndexKind::TableTag => merge_table_tag(merged, object_store, output).await,
         IndexKind::Tag => merge_tag(merged, object_store, output).await,
         IndexKind::TableTagTsid => merge_table_tag_tsid(merged, object_store, output).await,
-        IndexKind::PkMap => merge_passthrough(kind, merged, object_store, output).await,
+        IndexKind::PkMap => merge_pk_map(merged, object_store, output).await,
         IndexKind::PkColumns => unreachable!("PkColumns merge is rejected above"),
     }
 }
@@ -267,18 +269,53 @@ async fn merge_table_tag_tsid(
     writer.close().await
 }
 
-async fn merge_passthrough(
-    kind: IndexKind,
+async fn merge_pk_map(
     mut merged: SendableRecordBatchStream,
     object_store: &ObjectStore,
     output: &str,
 ) -> Result<usize> {
-    let mut writer = IndexWriter::try_new(object_store, output, kind.schema()).await?;
+    let mut writer = IndexWriter::try_new(object_store, output, IndexKind::PkMap.schema()).await?;
+    let mut buffer = PkMapOutputBuffer::default();
+    let mut current: Option<PkMapRow> = None;
+
     while let Some(batch) = merged.next().await {
         let batch = batch
-            .map_err(|e| external_error(e, format!("merge aggregate {kind:?} index stream")))?;
-        writer.write(&batch).await?;
+            .map_err(|e| external_error(e, "merge aggregate pk-map index stream".to_string()))?;
+        let pk = binary_col(&batch, 0)?;
+        let min = int64_col(&batch, 1)?;
+        let max = int64_col(&batch, 2)?;
+        let cnt = u64_col(&batch, 3)?;
+        let table = u32_col(&batch, 4)?;
+        let tsid = u64_col(&batch, 5)?;
+        let tags = map_col(&batch, 6)?;
+        for row in 0..batch.num_rows() {
+            let row = PkMapRow {
+                pk: pk.value(row).to_vec(),
+                min_ts: min.value(row),
+                max_ts: max.value(row),
+                row_count: cnt.value(row),
+                table_id: table.value(row),
+                tsid: tsid.value(row),
+                tags: map_entries(tags, row)?,
+            };
+            match current.as_mut() {
+                Some(current) if current.pk == row.pk => {
+                    current.min_ts = current.min_ts.min(row.min_ts);
+                    current.max_ts = current.max_ts.max(row.max_ts);
+                    current.row_count += row.row_count;
+                }
+                Some(_) => {
+                    let finished = current.replace(row).expect("current row exists");
+                    buffer.push(&mut writer, finished).await?;
+                }
+                None => current = Some(row),
+            }
+        }
     }
+    if let Some(row) = current.take() {
+        buffer.push(&mut writer, row).await?;
+    }
+    buffer.flush(&mut writer).await?;
     writer.close().await
 }
 
@@ -315,6 +352,17 @@ struct PkRow {
     min_ts: i64,
     max_ts: i64,
     row_count: u64,
+}
+
+#[derive(Debug)]
+struct PkMapRow {
+    pk: Vec<u8>,
+    min_ts: i64,
+    max_ts: i64,
+    row_count: u64,
+    table_id: u32,
+    tsid: u64,
+    tags: Vec<(u32, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -366,6 +414,88 @@ impl PkOutputBuffer {
                         .map(|row| row.row_count)
                         .collect::<Vec<_>>(),
                 )) as _,
+            ],
+        )
+        .context(NewRecordBatchSnafu)?;
+        writer.write(&batch).await?;
+        self.rows.clear();
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct PkMapOutputBuffer {
+    rows: Vec<PkMapRow>,
+}
+
+impl PkMapOutputBuffer {
+    async fn push(&mut self, writer: &mut IndexWriter, row: PkMapRow) -> Result<()> {
+        self.rows.push(row);
+        if self.rows.len() >= MERGE_BATCH_SIZE {
+            self.flush(writer).await?;
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self, writer: &mut IndexWriter) -> Result<()> {
+        if self.rows.is_empty() {
+            return Ok(());
+        }
+        let mut keys = Vec::new();
+        let mut values = Vec::new();
+        let mut lengths = Vec::new();
+        for row in &self.rows {
+            lengths.push(row.tags.len());
+            for (key, value) in &row.tags {
+                keys.push(*key);
+                values.push(value.as_str());
+            }
+        }
+        let key_field = Arc::new(Field::new(MAP_KEY_FIELD, DataType::UInt32, false));
+        let value_field = Arc::new(Field::new(MAP_VALUE_FIELD, DataType::Utf8, false));
+        let struct_array = StructArray::from(vec![
+            (key_field, Arc::new(UInt32Array::from(keys)) as ArrayRef),
+            (
+                value_field,
+                Arc::new(StringArray::from_iter_values(values)) as ArrayRef,
+            ),
+        ]);
+        let entries = match IndexKind::PkMap.schema().field(6).data_type() {
+            DataType::Map(entries, _) => entries.clone(),
+            _ => unreachable!("pk_map tags field is a map"),
+        };
+        let map = MapArray::new(
+            entries,
+            OffsetBuffer::from_lengths(lengths),
+            struct_array,
+            None,
+            false,
+        );
+        let batch = RecordBatch::try_new(
+            IndexKind::PkMap.schema(),
+            vec![
+                Arc::new(BinaryArray::from_iter_values(
+                    self.rows.iter().map(|row| row.pk.as_slice()),
+                )) as _,
+                Arc::new(Int64Array::from(
+                    self.rows.iter().map(|row| row.min_ts).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(Int64Array::from(
+                    self.rows.iter().map(|row| row.max_ts).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(UInt64Array::from(
+                    self.rows
+                        .iter()
+                        .map(|row| row.row_count)
+                        .collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(UInt32Array::from(
+                    self.rows.iter().map(|row| row.table_id).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(UInt64Array::from(
+                    self.rows.iter().map(|row| row.tsid).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(map) as _,
             ],
         )
         .context(NewRecordBatchSnafu)?;
@@ -503,6 +633,44 @@ fn string_col(batch: &RecordBatch, idx: usize) -> Result<&StringArray> {
         })
 }
 
+fn map_col(batch: &RecordBatch, idx: usize) -> Result<&MapArray> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<MapArray>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not Map"),
+        })
+}
+
+fn map_entries(array: &MapArray, row: usize) -> Result<Vec<(u32, String)>> {
+    let entries = array.value(row);
+    let entries =
+        entries
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .context(InvalidRecordBatchSnafu {
+                reason: "map entries are not StructArray".to_string(),
+            })?;
+    let keys = entries
+        .column(0)
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .context(InvalidRecordBatchSnafu {
+            reason: "map keys are not UInt32".to_string(),
+        })?;
+    let values = entries
+        .column(1)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .context(InvalidRecordBatchSnafu {
+            reason: "map values are not Utf8".to_string(),
+        })?;
+    Ok((0..entries.len())
+        .map(|idx| (keys.value(idx), values.value(idx).to_string()))
+        .collect())
+}
+
 fn external_error(error: impl std::fmt::Display, context: String) -> crate::error::Error {
     let boxed = common_error::ext::BoxedError::new(common_error::ext::PlainError::new(
         error.to_string(),
@@ -512,4 +680,126 @@ fn external_error(error: impl std::fmt::Display, context: String) -> crate::erro
     result
         .context(crate::error::ExternalSnafu { context })
         .unwrap_err()
+}
+
+#[cfg(test)]
+mod tests {
+    use common_test_util::temp_dir::create_temp_dir;
+    use object_store::services::Fs;
+
+    use super::*;
+
+    fn temp_store(root: &str) -> ObjectStore {
+        ObjectStore::new(Fs::default().root(root)).unwrap().finish()
+    }
+
+    fn pk_map_batch(rows: &[(&[u8], i64, i64, u64, u32, u64, &[(u32, &str)])]) -> RecordBatch {
+        let mut keys = Vec::new();
+        let mut values = Vec::new();
+        let mut lengths = Vec::new();
+        for row in rows {
+            lengths.push(row.6.len());
+            for (key, value) in row.6 {
+                keys.push(*key);
+                values.push(*value);
+            }
+        }
+        let key_field = Arc::new(Field::new(MAP_KEY_FIELD, DataType::UInt32, false));
+        let value_field = Arc::new(Field::new(MAP_VALUE_FIELD, DataType::Utf8, false));
+        let struct_array = StructArray::from(vec![
+            (key_field, Arc::new(UInt32Array::from(keys)) as ArrayRef),
+            (
+                value_field,
+                Arc::new(StringArray::from_iter_values(values)) as ArrayRef,
+            ),
+        ]);
+        let entries = match IndexKind::PkMap.schema().field(6).data_type() {
+            DataType::Map(entries, _) => entries.clone(),
+            _ => unreachable!("pk_map tags field is a map"),
+        };
+        let map = MapArray::new(
+            entries,
+            OffsetBuffer::from_lengths(lengths),
+            struct_array,
+            None,
+            false,
+        );
+
+        RecordBatch::try_new(
+            IndexKind::PkMap.schema(),
+            vec![
+                Arc::new(BinaryArray::from_iter_values(rows.iter().map(|row| row.0))) as _,
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|row| row.1).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(Int64Array::from(
+                    rows.iter().map(|row| row.2).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(UInt64Array::from(
+                    rows.iter().map(|row| row.3).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(UInt32Array::from(
+                    rows.iter().map(|row| row.4).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(UInt64Array::from(
+                    rows.iter().map(|row| row.5).collect::<Vec<_>>(),
+                )) as _,
+                Arc::new(map) as _,
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn write_pk_map_file(object_store: &ObjectStore, path: &str, batch: &RecordBatch) {
+        let mut writer = IndexWriter::try_new(object_store, path, IndexKind::PkMap.schema())
+            .await
+            .unwrap();
+        writer.write(batch).await.unwrap();
+        writer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_merge_pk_map_aggregates_duplicate_primary_keys() {
+        let dir = create_temp_dir("aggr_index_merge_pk_map");
+        let store = temp_store(dir.path().to_str().unwrap());
+        let tags = &[(7, "host-a"), (8, "region-a")];
+        write_pk_map_file(
+            &store,
+            "run1.parquet",
+            &pk_map_batch(&[(b"pk-a", 10, 20, 3, 42, 100, tags)]),
+        )
+        .await;
+        write_pk_map_file(
+            &store,
+            "run2.parquet",
+            &pk_map_batch(&[(b"pk-a", 5, 30, 4, 42, 100, tags)]),
+        )
+        .await;
+
+        let rows = merge_index_files(
+            IndexKind::PkMap,
+            &store,
+            &["run1.parquet".to_string(), "run2.parquet".to_string()],
+            "merged.parquet",
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows, 1);
+
+        let mut reader = IndexReader::try_new(&store, "merged.parquet", IndexKind::PkMap)
+            .await
+            .unwrap();
+        let batch = reader.next().await.unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(binary_col(&batch, 0).unwrap().value(0), b"pk-a");
+        assert_eq!(int64_col(&batch, 1).unwrap().value(0), 5);
+        assert_eq!(int64_col(&batch, 2).unwrap().value(0), 30);
+        assert_eq!(u64_col(&batch, 3).unwrap().value(0), 7);
+        assert_eq!(u32_col(&batch, 4).unwrap().value(0), 42);
+        assert_eq!(u64_col(&batch, 5).unwrap().value(0), 100);
+        assert_eq!(
+            map_entries(map_col(&batch, 6).unwrap(), 0).unwrap(),
+            vec![(7, "host-a".to_string()), (8, "region-a".to_string()),]
+        );
+    }
 }

--- a/src/mito2/src/aggr_index/mod.rs
+++ b/src/mito2/src/aggr_index/mod.rs
@@ -9,8 +9,10 @@ pub mod index_io;
 pub mod input;
 pub mod merge;
 pub mod schema;
+pub mod transform;
 
 pub use builder::{BuildOutput, build_indexes};
 pub use index_io::{IndexReader, IndexWriter};
 pub use merge::merge_index_files;
 pub use schema::IndexKind;
+pub use transform::{TransformFormat, TransformOutput, transform_pk_index};

--- a/src/mito2/src/aggr_index/schema.rs
+++ b/src/mito2/src/aggr_index/schema.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use datatypes::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datatypes::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef};
 use store_api::storage::ColumnId;
 use store_api::storage::consts::ReservedColumnId;
 
@@ -15,12 +15,19 @@ pub const ROW_COUNT_COL: &str = "row_count";
 pub const TABLE_ID_COL: &str = "__table_id";
 pub const COLUMN_ID_COL: &str = "column_id";
 pub const TAG_VALUE_COL: &str = "tag_value";
+pub const TSID_COL: &str = "__tsid";
+pub const TAGS_COL: &str = "tags";
+pub const MAP_KEY_FIELD: &str = "key";
+pub const MAP_VALUE_FIELD: &str = "value";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndexKind {
     Pk,
     TableTag,
     Tag,
+    TableTagTsid,
+    PkMap,
+    PkColumns,
 }
 
 impl IndexKind {
@@ -29,6 +36,9 @@ impl IndexKind {
             IndexKind::Pk => pk_schema(),
             IndexKind::TableTag => table_tag_schema(),
             IndexKind::Tag => tag_schema(),
+            IndexKind::TableTagTsid => table_tag_tsid_schema(),
+            IndexKind::PkMap => pk_map_schema(),
+            IndexKind::PkColumns => pk_columns_base_schema(),
         }
     }
 
@@ -37,6 +47,9 @@ impl IndexKind {
             IndexKind::Pk => "pk.parquet",
             IndexKind::TableTag => "table_tag.parquet",
             IndexKind::Tag => "tag.parquet",
+            IndexKind::TableTagTsid => "table_tag_tsid.parquet",
+            IndexKind::PkMap => "pk_map.parquet",
+            IndexKind::PkColumns => "pk_columns.parquet",
         }
     }
 }
@@ -58,6 +71,47 @@ pub fn table_tag_schema() -> SchemaRef {
     ]))
 }
 
+pub fn table_tag_tsid_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new(TABLE_ID_COL, DataType::UInt32, false),
+        Field::new(COLUMN_ID_COL, DataType::UInt32, false),
+        Field::new(TAG_VALUE_COL, DataType::Utf8, false),
+        Field::new(TSID_COL, DataType::UInt64, false),
+    ]))
+}
+
+pub fn pk_map_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new(PRIMARY_KEY_COL, DataType::Binary, false),
+        Field::new(MIN_TS_COL, DataType::Int64, false),
+        Field::new(MAX_TS_COL, DataType::Int64, false),
+        Field::new(ROW_COUNT_COL, DataType::UInt64, false),
+        Field::new(TABLE_ID_COL, DataType::UInt32, false),
+        Field::new(TSID_COL, DataType::UInt64, false),
+        tags_map_field(),
+    ]))
+}
+
+pub fn pk_columns_base_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new(PRIMARY_KEY_COL, DataType::Binary, false),
+        Field::new(MIN_TS_COL, DataType::Int64, false),
+        Field::new(MAX_TS_COL, DataType::Int64, false),
+        Field::new(ROW_COUNT_COL, DataType::UInt64, false),
+        Field::new(TABLE_ID_COL, DataType::UInt32, false),
+        Field::new(TSID_COL, DataType::UInt64, false),
+    ]))
+}
+
+pub fn tags_map_field() -> Field {
+    let entry_fields = Fields::from(vec![
+        Field::new(MAP_KEY_FIELD, DataType::UInt32, false),
+        Field::new(MAP_VALUE_FIELD, DataType::Utf8, false),
+    ]);
+    let entries = Field::new("entries", DataType::Struct(entry_fields), false);
+    Field::new(TAGS_COL, DataType::Map(Arc::new(entries), false), false)
+}
+
 pub fn tag_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new(COLUMN_ID_COL, DataType::UInt32, false),
@@ -66,6 +120,9 @@ pub fn tag_schema() -> SchemaRef {
 }
 
 pub fn validate_schema(kind: IndexKind, schema: &Schema) -> crate::error::Result<()> {
+    if kind == IndexKind::PkColumns {
+        return validate_pk_columns_schema(schema);
+    }
     if schema != kind.schema().as_ref() {
         return crate::error::InvalidMetaSnafu {
             reason: format!("invalid {:?} index schema: {schema:?}", kind),
@@ -75,6 +132,63 @@ pub fn validate_schema(kind: IndexKind, schema: &Schema) -> crate::error::Result
     Ok(())
 }
 
+fn validate_pk_columns_schema(schema: &Schema) -> crate::error::Result<()> {
+    let base = pk_columns_base_schema();
+    if schema.fields().len() < base.fields().len() {
+        return crate::error::InvalidMetaSnafu {
+            reason: format!("invalid PkColumns index schema: {schema:?}"),
+        }
+        .fail();
+    }
+    for (actual, expected) in schema
+        .fields()
+        .iter()
+        .take(base.fields().len())
+        .zip(base.fields())
+    {
+        if actual.as_ref() != expected.as_ref() {
+            return crate::error::InvalidMetaSnafu {
+                reason: format!("invalid PkColumns index schema: {schema:?}"),
+            }
+            .fail();
+        }
+    }
+    for field in schema.fields().iter().skip(base.fields().len()) {
+        if field.data_type() != &DataType::Utf8 || !field.is_nullable() {
+            return crate::error::InvalidMetaSnafu {
+                reason: format!("invalid PkColumns tag field: {field:?}"),
+            }
+            .fail();
+        }
+    }
+    Ok(())
+}
+
 pub fn is_reserved_tag_column(column_id: ColumnId) -> bool {
     column_id == ReservedColumnId::table_id() || column_id == ReservedColumnId::tsid()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_static_new_index_schemas_validate() {
+        validate_schema(IndexKind::TableTagTsid, table_tag_tsid_schema().as_ref()).unwrap();
+        validate_schema(IndexKind::PkMap, pk_map_schema().as_ref()).unwrap();
+    }
+
+    #[test]
+    fn test_pk_columns_dynamic_schema_validation() {
+        let mut fields = pk_columns_base_schema().fields().to_vec();
+        fields.push(Arc::new(Field::new("tag_0", DataType::Utf8, true)));
+        fields.push(Arc::new(Field::new("tag_1", DataType::Utf8, true)));
+        let schema = Schema::new(fields);
+        validate_schema(IndexKind::PkColumns, &schema).unwrap();
+
+        let mut fields = pk_columns_base_schema().fields().to_vec();
+        fields.push(Arc::new(Field::new("bad_tag", DataType::Utf8, false)));
+        let schema = Schema::new(fields);
+        assert!(validate_schema(IndexKind::PkColumns, &schema).is_err());
+    }
 }

--- a/src/mito2/src/aggr_index/transform.rs
+++ b/src/mito2/src/aggr_index/transform.rs
@@ -1,0 +1,562 @@
+// Copyright 2023 Greptime Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use datatypes::arrow::array::{
+    Array, ArrayRef, BinaryArray, Int64Array, MapArray, StringArray, StructArray, UInt32Array,
+    UInt64Array,
+};
+use datatypes::arrow::buffer::OffsetBuffer;
+use datatypes::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datatypes::arrow::record_batch::RecordBatch;
+use datatypes::value::Value;
+use futures::StreamExt;
+use mito_codec::row_converter::{CompositeValues, SparseValues, build_primary_key_codec};
+use object_store::ObjectStore;
+use snafu::{OptionExt, ResultExt, ensure};
+use store_api::codec::PrimaryKeyEncoding;
+use store_api::metadata::RegionMetadataRef;
+use store_api::storage::ColumnId;
+use store_api::storage::consts::ReservedColumnId;
+
+use crate::aggr_index::index_io::{IndexReader, IndexWriter};
+use crate::aggr_index::schema::{
+    IndexKind, MAP_KEY_FIELD, MAP_VALUE_FIELD, is_reserved_tag_column, pk_columns_base_schema,
+};
+use crate::error::{InvalidMetaSnafu, InvalidRecordBatchSnafu, NewRecordBatchSnafu, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TransformFormat {
+    TableTagTsid,
+    PkMap,
+    PkColumns,
+}
+
+impl TransformFormat {
+    pub fn kind(self) -> IndexKind {
+        match self {
+            Self::TableTagTsid => IndexKind::TableTagTsid,
+            Self::PkMap => IndexKind::PkMap,
+            Self::PkColumns => IndexKind::PkColumns,
+        }
+    }
+
+    pub fn all() -> Vec<Self> {
+        vec![Self::TableTagTsid, Self::PkMap, Self::PkColumns]
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TransformCosts {
+    pub read_iteration: Duration,
+    pub decode_transform: Duration,
+    pub table_tag_tsid_write: Duration,
+    pub pk_map_write: Duration,
+    pub pk_columns_write: Duration,
+}
+
+#[derive(Debug, Clone)]
+pub struct TransformOutput {
+    pub table_tag_tsid_path: Option<String>,
+    pub pk_map_path: Option<String>,
+    pub pk_columns_path: Option<String>,
+    pub table_tag_tsid_rows: usize,
+    pub pk_map_rows: usize,
+    pub pk_columns_rows: usize,
+    pub costs: TransformCosts,
+}
+
+#[derive(Debug, Clone)]
+struct DecodedPkRow {
+    pk: Vec<u8>,
+    min_ts: i64,
+    max_ts: i64,
+    row_count: u64,
+    table_id: u32,
+    tsid: u64,
+    tags: BTreeMap<ColumnId, String>,
+}
+
+pub async fn transform_pk_index(
+    metadata: RegionMetadataRef,
+    object_store: ObjectStore,
+    pk_input: &str,
+    output_dir: &str,
+    formats: &[TransformFormat],
+) -> Result<TransformOutput> {
+    ensure!(
+        metadata.primary_key_encoding == PrimaryKeyEncoding::Sparse,
+        InvalidMetaSnafu {
+            reason: "aggregate index transform only supports sparse primary-key encoding"
+        }
+    );
+
+    let formats = if formats.is_empty() {
+        TransformFormat::all()
+    } else {
+        formats.to_vec()
+    };
+    let output_dir = output_dir.trim_end_matches('/');
+    let codec = build_primary_key_codec(&metadata);
+    let tag_columns = tag_columns(&metadata);
+
+    let read_start = Instant::now();
+    let mut reader = IndexReader::try_new(&object_store, pk_input, IndexKind::Pk).await?;
+    let mut batches = Vec::new();
+    while let Some(batch) = reader.next().await {
+        batches.push(batch?);
+    }
+    let read_iteration = read_start.elapsed();
+
+    let decode_start = Instant::now();
+    let mut rows = Vec::new();
+    for batch in &batches {
+        let pk = binary_col(batch, 0)?;
+        let min = int64_col(batch, 1)?;
+        let max = int64_col(batch, 2)?;
+        let cnt = u64_col(batch, 3)?;
+        for row in 0..batch.num_rows() {
+            let sparse = match codec
+                .decode(pk.value(row))
+                .context(crate::error::DecodeSnafu)?
+            {
+                CompositeValues::Sparse(sparse) => sparse,
+                other => {
+                    return InvalidMetaSnafu {
+                        reason: format!("decoded primary key is not sparse: {other:?}"),
+                    }
+                    .fail();
+                }
+            };
+            let table_id = required_u32(&sparse, ReservedColumnId::table_id(), "__table_id")?;
+            let tsid = required_u64(&sparse, ReservedColumnId::tsid(), "__tsid")?;
+            let mut tags = BTreeMap::new();
+            for (column_id, _) in &tag_columns {
+                if let Some(value) = sparse.get(column_id) {
+                    tags.insert(*column_id, string_value(*column_id, value)?);
+                }
+            }
+            rows.push(DecodedPkRow {
+                pk: pk.value(row).to_vec(),
+                min_ts: min.value(row),
+                max_ts: max.value(row),
+                row_count: cnt.value(row),
+                table_id,
+                tsid,
+                tags,
+            });
+        }
+    }
+    let decode_transform = decode_start.elapsed();
+
+    let mut output = TransformOutput {
+        table_tag_tsid_path: None,
+        pk_map_path: None,
+        pk_columns_path: None,
+        table_tag_tsid_rows: 0,
+        pk_map_rows: 0,
+        pk_columns_rows: 0,
+        costs: TransformCosts {
+            read_iteration,
+            decode_transform,
+            ..Default::default()
+        },
+    };
+
+    if formats.contains(&TransformFormat::TableTagTsid) {
+        let path = format!("{output_dir}/{}", IndexKind::TableTagTsid.file_name());
+        let start = Instant::now();
+        output.table_tag_tsid_rows = write_table_tag_tsid(&object_store, &path, &rows).await?;
+        output.costs.table_tag_tsid_write = start.elapsed();
+        output.table_tag_tsid_path = Some(path);
+    }
+    if formats.contains(&TransformFormat::PkMap) {
+        let path = format!("{output_dir}/{}", IndexKind::PkMap.file_name());
+        let start = Instant::now();
+        output.pk_map_rows = write_pk_map(&object_store, &path, &rows).await?;
+        output.costs.pk_map_write = start.elapsed();
+        output.pk_map_path = Some(path);
+    }
+    if formats.contains(&TransformFormat::PkColumns) {
+        let path = format!("{output_dir}/{}", IndexKind::PkColumns.file_name());
+        let start = Instant::now();
+        output.pk_columns_rows =
+            write_pk_columns(&object_store, &path, &rows, &tag_columns).await?;
+        output.costs.pk_columns_write = start.elapsed();
+        output.pk_columns_path = Some(path);
+    }
+
+    Ok(output)
+}
+
+async fn write_table_tag_tsid(
+    object_store: &ObjectStore,
+    path: &str,
+    rows: &[DecodedPkRow],
+) -> Result<usize> {
+    let mut table_ids = Vec::new();
+    let mut column_ids = Vec::new();
+    let mut values = Vec::new();
+    let mut tsids = Vec::new();
+    for row in rows {
+        for (column_id, value) in &row.tags {
+            table_ids.push(row.table_id);
+            column_ids.push(*column_id);
+            values.push(value.as_str());
+            tsids.push(row.tsid);
+        }
+    }
+    let batch = RecordBatch::try_new(
+        IndexKind::TableTagTsid.schema(),
+        vec![
+            Arc::new(UInt32Array::from(table_ids)) as _,
+            Arc::new(UInt32Array::from(column_ids)) as _,
+            Arc::new(StringArray::from_iter_values(values)) as _,
+            Arc::new(UInt64Array::from(tsids)) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    write_one_batch(object_store, path, IndexKind::TableTagTsid.schema(), batch).await
+}
+
+async fn write_pk_map(
+    object_store: &ObjectStore,
+    path: &str,
+    rows: &[DecodedPkRow],
+) -> Result<usize> {
+    let mut keys = Vec::new();
+    let mut values = Vec::new();
+    let mut lengths = Vec::new();
+    for row in rows {
+        lengths.push(row.tags.len());
+        for (column_id, value) in &row.tags {
+            keys.push(*column_id);
+            values.push(value.as_str());
+        }
+    }
+    let key_field = Arc::new(Field::new(MAP_KEY_FIELD, DataType::UInt32, false));
+    let value_field = Arc::new(Field::new(MAP_VALUE_FIELD, DataType::Utf8, false));
+    let struct_array = StructArray::from(vec![
+        (key_field, Arc::new(UInt32Array::from(keys)) as ArrayRef),
+        (
+            value_field,
+            Arc::new(StringArray::from_iter_values(values)) as ArrayRef,
+        ),
+    ]);
+    let entries = match IndexKind::PkMap.schema().field(6).data_type() {
+        DataType::Map(entries, _) => entries.clone(),
+        _ => unreachable!("pk_map tags field is a map"),
+    };
+    let map = MapArray::new(
+        entries,
+        OffsetBuffer::from_lengths(lengths),
+        struct_array,
+        None,
+        false,
+    );
+
+    let batch = RecordBatch::try_new(
+        IndexKind::PkMap.schema(),
+        vec![
+            Arc::new(BinaryArray::from_iter_values(
+                rows.iter().map(|row| row.pk.as_slice()),
+            )) as _,
+            Arc::new(Int64Array::from(
+                rows.iter().map(|row| row.min_ts).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(Int64Array::from(
+                rows.iter().map(|row| row.max_ts).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(UInt64Array::from(
+                rows.iter().map(|row| row.row_count).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(UInt32Array::from(
+                rows.iter().map(|row| row.table_id).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(UInt64Array::from(
+                rows.iter().map(|row| row.tsid).collect::<Vec<_>>(),
+            )) as _,
+            Arc::new(map) as _,
+        ],
+    )
+    .context(NewRecordBatchSnafu)?;
+    write_one_batch(object_store, path, IndexKind::PkMap.schema(), batch).await
+}
+
+async fn write_pk_columns(
+    object_store: &ObjectStore,
+    path: &str,
+    rows: &[DecodedPkRow],
+    tag_columns: &[(ColumnId, String)],
+) -> Result<usize> {
+    let mut fields = pk_columns_base_schema().fields().to_vec();
+    fields.extend(
+        tag_columns
+            .iter()
+            .map(|(_, name)| Arc::new(Field::new(name, DataType::Utf8, true))),
+    );
+    let schema = Arc::new(Schema::new(fields));
+    let mut arrays: Vec<ArrayRef> = vec![
+        Arc::new(BinaryArray::from_iter_values(
+            rows.iter().map(|row| row.pk.as_slice()),
+        )) as _,
+        Arc::new(Int64Array::from(
+            rows.iter().map(|row| row.min_ts).collect::<Vec<_>>(),
+        )) as _,
+        Arc::new(Int64Array::from(
+            rows.iter().map(|row| row.max_ts).collect::<Vec<_>>(),
+        )) as _,
+        Arc::new(UInt64Array::from(
+            rows.iter().map(|row| row.row_count).collect::<Vec<_>>(),
+        )) as _,
+        Arc::new(UInt32Array::from(
+            rows.iter().map(|row| row.table_id).collect::<Vec<_>>(),
+        )) as _,
+        Arc::new(UInt64Array::from(
+            rows.iter().map(|row| row.tsid).collect::<Vec<_>>(),
+        )) as _,
+    ];
+    for (column_id, _) in tag_columns {
+        let values = rows
+            .iter()
+            .map(|row| row.tags.get(column_id).map(|v| v.as_str()))
+            .collect::<Vec<_>>();
+        arrays.push(Arc::new(StringArray::from(values)) as _);
+    }
+    let batch = RecordBatch::try_new(schema.clone(), arrays).context(NewRecordBatchSnafu)?;
+    write_one_batch(object_store, path, schema, batch).await
+}
+
+async fn write_one_batch(
+    object_store: &ObjectStore,
+    path: &str,
+    schema: SchemaRef,
+    batch: RecordBatch,
+) -> Result<usize> {
+    let mut writer = IndexWriter::try_new(object_store, path, schema).await?;
+    writer.write(&batch).await?;
+    writer.close().await
+}
+
+fn tag_columns(metadata: &RegionMetadataRef) -> Vec<(ColumnId, String)> {
+    metadata
+        .primary_key_columns()
+        .filter(|col| !is_reserved_tag_column(col.column_id))
+        .map(|col| (col.column_id, col.column_schema.name.clone()))
+        .collect()
+}
+
+fn required_u32(values: &SparseValues, column_id: ColumnId, name: &str) -> Result<u32> {
+    match values.get(&column_id) {
+        Some(Value::UInt32(v)) => Ok(*v),
+        other => InvalidMetaSnafu {
+            reason: format!("missing/invalid sparse {name}: {other:?}"),
+        }
+        .fail(),
+    }
+}
+
+fn required_u64(values: &SparseValues, column_id: ColumnId, name: &str) -> Result<u64> {
+    match values.get(&column_id) {
+        Some(Value::UInt64(v)) => Ok(*v),
+        other => InvalidMetaSnafu {
+            reason: format!("missing/invalid sparse {name}: {other:?}"),
+        }
+        .fail(),
+    }
+}
+
+fn string_value(column_id: ColumnId, value: &Value) -> Result<String> {
+    match value {
+        Value::String(value) => Ok(value.as_utf8().to_string()),
+        other => InvalidMetaSnafu {
+            reason: format!("aggregate PK transform expects string tag value for column {column_id}, got {other:?}"),
+        }
+        .fail(),
+    }
+}
+
+fn binary_col(batch: &RecordBatch, idx: usize) -> Result<&BinaryArray> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<BinaryArray>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not Binary"),
+        })
+}
+fn int64_col(batch: &RecordBatch, idx: usize) -> Result<&Int64Array> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not Int64"),
+        })
+}
+fn u64_col(batch: &RecordBatch, idx: usize) -> Result<&UInt64Array> {
+    batch
+        .column(idx)
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .context(InvalidRecordBatchSnafu {
+            reason: format!("column {idx} is not UInt64"),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use common_test_util::temp_dir::create_temp_dir;
+    use datatypes::arrow::array::StringArray;
+    use datatypes::value::ValueRef;
+    use object_store::services::Fs;
+    use store_api::codec::PrimaryKeyEncoding;
+
+    use super::*;
+    use crate::test_util::sst_util::sst_region_metadata_with_encoding;
+
+    fn temp_store(root: &str) -> ObjectStore {
+        ObjectStore::new(Fs::default().root(root)).unwrap().finish()
+    }
+
+    fn encode_pk(
+        metadata: &RegionMetadataRef,
+        table_id: u32,
+        tsid: u64,
+        tag_0: Option<&str>,
+        tag_1: Option<&str>,
+    ) -> Vec<u8> {
+        let codec = build_primary_key_codec(metadata);
+        let mut values = vec![
+            (ReservedColumnId::table_id(), ValueRef::UInt32(table_id)),
+            (ReservedColumnId::tsid(), ValueRef::UInt64(tsid)),
+        ];
+        if let Some(v) = tag_0 {
+            values.push((0, ValueRef::String(v)));
+        }
+        if let Some(v) = tag_1 {
+            values.push((1, ValueRef::String(v)));
+        }
+        let mut buffer = Vec::new();
+        codec.encode_value_refs(&values, &mut buffer).unwrap();
+        buffer
+    }
+
+    async fn write_legacy_pk(store: &ObjectStore, metadata: &RegionMetadataRef, path: &str) {
+        let rows = vec![
+            encode_pk(metadata, 11, 101, Some("a"), Some("x")),
+            encode_pk(metadata, 11, 102, Some("b"), None),
+        ];
+        let batch = RecordBatch::try_new(
+            IndexKind::Pk.schema(),
+            vec![
+                Arc::new(BinaryArray::from_iter_values(
+                    rows.iter().map(|v| v.as_slice()),
+                )) as _,
+                Arc::new(Int64Array::from(vec![1, 3])) as _,
+                Arc::new(Int64Array::from(vec![2, 5])) as _,
+                Arc::new(UInt64Array::from(vec![10, 20])) as _,
+            ],
+        )
+        .unwrap();
+        let mut writer = IndexWriter::try_new(store, path, IndexKind::Pk.schema())
+            .await
+            .unwrap();
+        writer.write(&batch).await.unwrap();
+        writer.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_transform_pk_outputs() {
+        let dir = create_temp_dir("aggr_index_transform");
+        let store = temp_store(dir.path().to_str().unwrap());
+        let metadata = Arc::new(sst_region_metadata_with_encoding(
+            PrimaryKeyEncoding::Sparse,
+        ));
+        write_legacy_pk(&store, &metadata, "old/pk.parquet").await;
+
+        let output = transform_pk_index(metadata, store.clone(), "old/pk.parquet", "new", &[])
+            .await
+            .unwrap();
+        assert_eq!(output.table_tag_tsid_rows, 3);
+        assert_eq!(output.pk_map_rows, 2);
+        assert_eq!(output.pk_columns_rows, 2);
+
+        let mut reader = IndexReader::try_new(
+            &store,
+            "new/table_tag_tsid.parquet",
+            IndexKind::TableTagTsid,
+        )
+        .await
+        .unwrap();
+        let batch = reader.next().await.unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 3);
+
+        let mut reader = IndexReader::try_new(&store, "new/pk_map.parquet", IndexKind::PkMap)
+            .await
+            .unwrap();
+        let batch = reader.next().await.unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+        let table = batch
+            .column(4)
+            .as_any()
+            .downcast_ref::<UInt32Array>()
+            .unwrap();
+        let tsid = batch
+            .column(5)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(table.value(0), 11);
+        assert_eq!(tsid.value(1), 102);
+
+        let mut reader =
+            IndexReader::try_new(&store, "new/pk_columns.parquet", IndexKind::PkColumns)
+                .await
+                .unwrap();
+        let batch = reader.next().await.unwrap().unwrap();
+        assert_eq!(batch.schema().field(6).name(), "tag_0");
+        assert_eq!(batch.schema().field(7).name(), "tag_1");
+        let tag_0 = batch
+            .column(6)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let tag_1 = batch
+            .column(7)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(tag_0.value(0), "a");
+        assert!(tag_1.is_null(1));
+    }
+
+    #[tokio::test]
+    async fn test_transform_format_selection() {
+        let dir = create_temp_dir("aggr_index_transform_selection");
+        let store = temp_store(dir.path().to_str().unwrap());
+        let metadata = Arc::new(sst_region_metadata_with_encoding(
+            PrimaryKeyEncoding::Sparse,
+        ));
+        write_legacy_pk(&store, &metadata, "old/pk.parquet").await;
+
+        let output = transform_pk_index(
+            metadata,
+            store.clone(),
+            "old/pk.parquet",
+            "new",
+            &[TransformFormat::PkMap],
+        )
+        .await
+        .unwrap();
+        assert!(output.table_tag_tsid_path.is_none());
+        assert!(output.pk_columns_path.is_none());
+        assert_eq!(output.pk_map_rows, 2);
+        assert!(store.stat("new/pk_map.parquet").await.is_ok());
+        assert!(store.stat("new/table_tag_tsid.parquet").await.is_err());
+    }
+}


### PR DESCRIPTION
### Motivation

- Support new PK-derived aggregate index formats (table+tag+tsid, PK->map, PK->columns) while keeping the legacy `pk.parquet` output unchanged. 
- Provide a transform path to convert an existing legacy `pk.parquet` into the new formats using representative SST metadata so sparse PKs can be decoded offline. 
- Add simple cost/timing visibility for build and transform phases to help profile IO and decode/transform work. 

### Description

- Added new `IndexKind` variants and schemas: `TableTagTsid`, `PkMap`, and metadata-derived `PkColumns`, with `PkColumns` supporting dynamic schema validation via `pk_columns_base_schema()` and `validate_pk_columns_schema()`. 
- Implemented `transform_pk_index` in `mito2::aggr_index::transform` to read legacy `pk.parquet`, decode sparse primary keys with a codec built from SST metadata, extract `__table_id`, `__tsid`, and tag values, and write selected outputs (`table_tag_tsid.parquet`, `pk_map.parquet`, `pk_columns.parquet`). 
- Extended merge logic to support new static kinds (`TableTagTsid` merge with duplicate elimination and `PkMap` passthrough); `PkColumns` is explicitly rejected from generic merge because its schema is metadata-derived. 
- Kept build behavior producing the legacy `pk.parquet` but added `BuildCosts` and timing collection (SST iteration/decode/collect, legacy PK write, per-run writes, final merge writes). 
- Extended CLI `aggr-index` with a new `transform-pk` subcommand (`TransformPkCommand`) and `--format` selection (`--format` repeatable: `table-tag-tsid`, `map`, `columns`), added read/print support for the new kinds and human-readable cost output. 
- Added readers/writers and printers for the new index kinds (map field handling, nullable per-tag columns for `PkColumns`). 
- Added unit tests for schema validation and transform behavior (verify `TableTagTsid`, `PkMap`, and `PkColumns` outputs and format selection). 

### Testing

- Ran `cargo fmt` successfully to format changes. 
- Ran `cargo check -p mito2 --lib` and `cargo check -p cmd` successfully. 
- Ran `cargo test -p mito2 aggr_index --lib` and all aggr_index tests passed (10 passed, 0 failed). 
- Note: `cargo nextest` was not available in the environment so `cargo nextest run -p mito2 aggr_index` and `cargo nextest run -p cmd aggr_index` were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2956e974648329a1d5cd3793a7a296)